### PR TITLE
feat: user caching + 24h TTL for all caches

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -54,7 +54,7 @@ func (c *AuthLoginCmd) runDesktop(cli *CLI) error {
 	workspaces, err := auth.DesktopLogin(ctx, auth.DesktopLoginOptions{
 		HTTPClient: api.ChromeTLSClient(),
 		StatusFunc: func(msg string) {
-			p.PrintError(&output.Error{Err: "status", Detail: msg})
+			_ = p.PrintError(&output.Error{Err: "status", Detail: msg})
 		},
 	})
 	if err != nil {

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -96,7 +96,7 @@ func TestClassifyError_AuthHints(t *testing.T) {
 func TestAuthStatus_WorkspaceFilter(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/auth.test", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":      true,
 			"url":     "https://test.slack.com/",
 			"team":    "Test Team",
@@ -119,7 +119,7 @@ func TestAuthStatus_WorkspaceFilter(t *testing.T) {
 		},
 	}
 	credsPath, _ := auth.DefaultCredentialsPath()
-	auth.SaveCredentials(credsPath, creds)
+	_ = auth.SaveCredentials(credsPath, creds)
 
 	t.Setenv("SLACK_API_URL", srv.URL+"/api/")
 
@@ -154,7 +154,7 @@ func TestAuthStatus_DesktopWorkspace(t *testing.T) {
 	var gotCookie string
 	mux.HandleFunc("/api/auth.test", func(w http.ResponseWriter, r *http.Request) {
 		gotCookie = r.Header.Get("Cookie")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":      true,
 			"url":     "https://test.slack.com/",
 			"team":    "Test Team",

--- a/cmd/channel.go
+++ b/cmd/channel.go
@@ -221,6 +221,6 @@ func channelToMap(ch slack.Channel) map[string]any {
 	// Marshal via JSON to get a flat map with correct field names.
 	data, _ := json.Marshal(ch)
 	var m map[string]any
-	json.Unmarshal(data, &m)
+	_ = json.Unmarshal(data, &m)
 	return m
 }

--- a/cmd/channel_test.go
+++ b/cmd/channel_test.go
@@ -114,7 +114,7 @@ func TestChannelList_PaginationFlags(t *testing.T) {
 func TestChannelList_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true,
 			"channels": []map[string]any{
 				{"id": "C01", "name": "general", "is_channel": true, "is_member": true, "num_members": 10},
@@ -151,7 +151,7 @@ func TestChannelList_MockAPI(t *testing.T) {
 func TestChannelList_IncludeNonMember(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true,
 			"channels": []map[string]any{
 				{"id": "C01", "name": "general", "is_channel": true, "is_member": true},
@@ -175,7 +175,7 @@ func TestChannelList_IncludeNonMember(t *testing.T) {
 func TestChannelList_QueryFilter(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true,
 			"channels": []map[string]any{
 				{"id": "C01", "name": "general", "is_channel": true, "is_member": true},
@@ -201,7 +201,7 @@ func TestChannelList_QueryFilter(t *testing.T) {
 func TestChannelList_HasUnread(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true,
 			"channels": []map[string]any{
 				{"id": "C01", "name": "general", "is_channel": true, "is_member": true, "unread_count": 5},
@@ -227,17 +227,17 @@ func TestChannelList_Pagination(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
 		callCount++
-		r.ParseForm()
+		_ = r.ParseForm()
 		cursor := r.FormValue("cursor")
 
 		if cursor == "" {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":       true,
 				"channels": []map[string]any{{"id": "C01", "name": "page1", "is_member": true}},
 				"response_metadata": map[string]string{"next_cursor": "page2cursor"},
 			})
 		} else {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":       true,
 				"channels": []map[string]any{{"id": "C02", "name": "page2", "is_member": true}},
 				"response_metadata": map[string]string{"next_cursor": ""},
@@ -268,16 +268,16 @@ func TestChannelList_Pagination(t *testing.T) {
 func TestChannelList_AllPages(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		cursor := r.FormValue("cursor")
 		if cursor == "" {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":       true,
 				"channels": []map[string]any{{"id": "C01", "name": "page1", "is_member": true}},
 				"response_metadata": map[string]string{"next_cursor": "page2cursor"},
 			})
 		} else {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":       true,
 				"channels": []map[string]any{{"id": "C02", "name": "page2", "is_member": true}},
 				"response_metadata": map[string]string{"next_cursor": ""},
@@ -305,14 +305,14 @@ func TestChannelList_AllPages(t *testing.T) {
 func TestChannelInfo_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"channels": []map[string]any{{"id": "C01", "name": "general"}},
 			"response_metadata": map[string]string{"next_cursor": ""},
 		})
 	})
 	mux.HandleFunc("/api/conversations.info", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":      true,
 			"channel": map[string]any{"id": "C01", "name": "general", "is_channel": true, "num_members": 42},
 		})
@@ -337,14 +337,14 @@ func TestChannelInfo_MockAPI(t *testing.T) {
 func TestChannelInfo_InlineError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"channels": []map[string]any{{"id": "C01", "name": "general"}},
 			"response_metadata": map[string]string{"next_cursor": ""},
 		})
 	})
 	mux.HandleFunc("/api/conversations.info", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":      true,
 			"channel": map[string]any{"id": "C01", "name": "general"},
 		})
@@ -377,7 +377,7 @@ func TestChannelInfo_InlineError(t *testing.T) {
 func TestChannelMembers_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.members", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":                true,
 			"members":          []string{"U01", "U02", "U03"},
 			"response_metadata": map[string]string{"next_cursor": ""},
@@ -403,14 +403,14 @@ func TestChannelMembers_MockAPI(t *testing.T) {
 func TestChannelInfo_PartialFailure_NoStderr(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"channels": []map[string]any{{"id": "C01", "name": "general"}},
 			"response_metadata": map[string]string{"next_cursor": ""},
 		})
 	})
 	mux.HandleFunc("/api/conversations.info", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":      true,
 			"channel": map[string]any{"id": "C01", "name": "general"},
 		})

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -186,7 +186,7 @@ func (c *MessageGetCmd) Run(cli *CLI) error {
 func messageToMap(msg slack.Message) map[string]any {
 	data, _ := json.Marshal(msg)
 	var m map[string]any
-	json.Unmarshal(data, &m)
+	_ = json.Unmarshal(data, &m)
 	return m
 }
 

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -9,7 +9,7 @@ import (
 func TestMessageList_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.history", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"has_more": false,
 			"messages": []map[string]any{
@@ -43,7 +43,7 @@ func TestMessageList_MockAPI(t *testing.T) {
 func TestMessageList_HasRepliesFilter(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.history", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"has_more": false,
 			"messages": []map[string]any{
@@ -73,7 +73,7 @@ func TestMessageList_HasRepliesFilter(t *testing.T) {
 func TestMessageList_HasReactionsFilter(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.history", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"has_more": false,
 			"messages": []map[string]any{
@@ -98,15 +98,15 @@ func TestMessageList_HasReactionsFilter(t *testing.T) {
 func TestMessageGet_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.history", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		oldest := r.FormValue("oldest")
 		if oldest == "1709251200.000100" {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":       true,
 				"messages": []map[string]any{{"type": "message", "user": "U01", "text": "found", "ts": "1709251200.000100"}},
 			})
 		} else {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":       true,
 				"messages": []map[string]any{},
 			})
@@ -132,7 +132,7 @@ func TestMessageGet_MockAPI(t *testing.T) {
 func TestMessageGet_NotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.history", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"messages": []map[string]any{},
 		})
@@ -157,7 +157,7 @@ func TestMessageGet_NotFound(t *testing.T) {
 func TestMessageList_Pagination(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.history", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"has_more": true,
 			"messages": []map[string]any{{"type": "message", "text": "msg1", "ts": "1709251200.000100"}},

--- a/cmd/permalink_test.go
+++ b/cmd/permalink_test.go
@@ -9,8 +9,8 @@ import (
 func TestMessagePermalink_SingleTimestamp(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/chat.getPermalink", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = r.ParseForm()
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":        true,
 			"channel":   r.FormValue("channel"),
 			"permalink": "https://acme.slack.com/archives/C01ABC/p1709251200000100",
@@ -49,10 +49,10 @@ func TestMessagePermalink_MultipleTimestamps(t *testing.T) {
 	mux := http.NewServeMux()
 	callCount := 0
 	mux.HandleFunc("/api/chat.getPermalink", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		callCount++
 		ts := r.FormValue("message_ts")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":        true,
 			"channel":   r.FormValue("channel"),
 			"permalink": "https://acme.slack.com/archives/C01ABC/p" + ts,
@@ -89,7 +89,7 @@ func TestMessagePermalink_MultipleTimestamps(t *testing.T) {
 func TestMessagePermalink_ChannelResolution(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true,
 			"channels": []map[string]any{
 				{"id": "C01ABC", "name": "general", "is_member": true},
@@ -98,12 +98,12 @@ func TestMessagePermalink_ChannelResolution(t *testing.T) {
 		})
 	})
 	mux.HandleFunc("/api/chat.getPermalink", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		ch := r.FormValue("channel")
 		if ch != "C01ABC" {
 			t.Errorf("expected resolved channel C01ABC, got %q", ch)
 		}
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":        true,
 			"channel":   ch,
 			"permalink": "https://acme.slack.com/archives/C01ABC/p100",
@@ -129,7 +129,7 @@ func TestMessagePermalink_ChannelResolution(t *testing.T) {
 func TestMessagePermalink_AuthError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/chat.getPermalink", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":    false,
 			"error": "not_authed",
 		})
@@ -147,14 +147,14 @@ func TestMessagePermalink_PartialFailure(t *testing.T) {
 	mux.HandleFunc("/api/chat.getPermalink", func(w http.ResponseWriter, r *http.Request) {
 		call++
 		if call == 2 {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":    false,
 				"error": "message_not_found",
 			})
 			return
 		}
-		r.ParseForm()
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = r.ParseForm()
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":        true,
 			"channel":   r.FormValue("channel"),
 			"permalink": "https://acme.slack.com/archives/C01ABC/pOK",
@@ -190,7 +190,7 @@ func TestMessagePermalink_PartialFailure(t *testing.T) {
 func TestMessagePermalink_Fields(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/chat.getPermalink", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":        true,
 			"channel":   "C01ABC",
 			"permalink": "https://acme.slack.com/archives/C01ABC/p100",

--- a/cmd/reaction_test.go
+++ b/cmd/reaction_test.go
@@ -9,7 +9,7 @@ import (
 func TestReactionList_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/reactions.get", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":   true,
 			"type": "message",
 			"message": map[string]any{
@@ -47,7 +47,7 @@ func TestReactionList_MockAPI(t *testing.T) {
 func TestReactionList_NoReactions(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/reactions.get", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":   true,
 			"type": "message",
 			"message": map[string]any{
@@ -71,10 +71,10 @@ func TestReactionList_NoReactions(t *testing.T) {
 func TestReactionList_MultipleTimestamps(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/reactions.get", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		ts := r.FormValue("timestamp")
 		if ts == "1709251200.000100" {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":   true,
 				"type": "message",
 				"message": map[string]any{
@@ -84,7 +84,7 @@ func TestReactionList_MultipleTimestamps(t *testing.T) {
 				},
 			})
 		} else {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":    false,
 				"error": "message_not_found",
 			})

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -111,6 +111,6 @@ func (c *SearchMessagesCmd) Run(cli *CLI) error {
 func searchMessageToMap(msg slack.SearchMessage) map[string]any {
 	data, _ := json.Marshal(msg)
 	var m map[string]any
-	json.Unmarshal(data, &m)
+	_ = json.Unmarshal(data, &m)
 	return m
 }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -44,11 +44,11 @@ func searchMatch(ts, text, user, username, channelID, channelName, permalink str
 func TestSearchMessages_Basic(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/search.messages", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		if q := r.Form.Get("query"); q != "deploy failed" {
 			t.Errorf("expected query 'deploy failed', got %q", q)
 		}
-		json.NewEncoder(w).Encode(searchResponse(
+		_ = json.NewEncoder(w).Encode(searchResponse(
 			[]map[string]any{
 				searchMatch("1709251200.000100", "The deploy failed at 3am", "U01XYZ", "tammer", "C01ABC", "general", "https://acme.slack.com/archives/C01ABC/p1709251200000100"),
 				searchMatch("1709164800.000050", "deploy failed again", "U02ABC", "alice", "C03GHI", "engineering", "https://acme.slack.com/archives/C03GHI/p1709164800000050"),
@@ -96,18 +96,18 @@ func TestSearchMessages_Pagination(t *testing.T) {
 	callCount := 0
 	mux.HandleFunc("/api/search.messages", func(w http.ResponseWriter, r *http.Request) {
 		callCount++
-		r.ParseForm()
+		_ = r.ParseForm()
 		page := r.Form.Get("page")
 
 		if page == "" || page == "1" {
-			json.NewEncoder(w).Encode(searchResponse(
+			_ = json.NewEncoder(w).Encode(searchResponse(
 				[]map[string]any{
 					searchMatch("1709251200.000100", "msg1", "U01", "tammer", "C01", "general", "https://x/p1"),
 				},
 				1, 2, 2,
 			))
 		} else if page == "2" {
-			json.NewEncoder(w).Encode(searchResponse(
+			_ = json.NewEncoder(w).Encode(searchResponse(
 				[]map[string]any{
 					searchMatch("1709164800.000050", "msg2", "U02", "alice", "C01", "general", "https://x/p2"),
 				},
@@ -144,9 +144,9 @@ func TestSearchMessages_Pagination(t *testing.T) {
 	callCount = 0
 	mux2 := http.NewServeMux()
 	mux2.HandleFunc("/api/search.messages", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		page2Requested = r.Form.Get("page")
-		json.NewEncoder(w).Encode(searchResponse(
+		_ = json.NewEncoder(w).Encode(searchResponse(
 			[]map[string]any{
 				searchMatch("1709164800.000050", "msg2", "U02", "alice", "C01", "general", "https://x/p2"),
 			},
@@ -182,18 +182,18 @@ func TestSearchMessages_Pagination(t *testing.T) {
 func TestSearchMessages_All(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/search.messages", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		page := r.Form.Get("page")
 
 		if page == "" || page == "1" {
-			json.NewEncoder(w).Encode(searchResponse(
+			_ = json.NewEncoder(w).Encode(searchResponse(
 				[]map[string]any{
 					searchMatch("1.1", "msg1", "U01", "a", "C01", "g", "https://x/1"),
 				},
 				1, 2, 2,
 			))
 		} else {
-			json.NewEncoder(w).Encode(searchResponse(
+			_ = json.NewEncoder(w).Encode(searchResponse(
 				[]map[string]any{
 					searchMatch("2.2", "msg2", "U02", "b", "C01", "g", "https://x/2"),
 				},
@@ -224,7 +224,7 @@ func TestSearchMessages_All(t *testing.T) {
 func TestSearchMessages_SortFlags(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/search.messages", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		// CLI default is "timestamp" which differs from slack-go's default "score",
 		// so it should always be sent.
 		if s := r.Form.Get("sort"); s != "timestamp" {
@@ -233,7 +233,7 @@ func TestSearchMessages_SortFlags(t *testing.T) {
 		if d := r.Form.Get("sort_dir"); d != "asc" {
 			t.Errorf("expected sort_dir=asc, got %q", d)
 		}
-		json.NewEncoder(w).Encode(searchResponse(nil, 1, 1, 0))
+		_ = json.NewEncoder(w).Encode(searchResponse(nil, 1, 1, 0))
 	})
 
 	t.Setenv("SLACK_USER_TOKEN", "xoxp-test")
@@ -267,7 +267,7 @@ func TestSearchMessages_MissingUserToken(t *testing.T) {
 func TestSearchMessages_NotAuthed(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/search.messages", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":    false,
 			"error": "not_authed",
 		})

--- a/cmd/thread_test.go
+++ b/cmd/thread_test.go
@@ -9,7 +9,7 @@ import (
 func TestThreadList_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.replies", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"has_more": false,
 			"messages": []map[string]any{
@@ -46,7 +46,7 @@ func TestThreadList_MockAPI(t *testing.T) {
 func TestThreadList_EmptyThread(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.replies", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"has_more": false,
 			"messages": []map[string]any{},
@@ -64,7 +64,7 @@ func TestThreadList_NoReplies(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.replies", func(w http.ResponseWriter, r *http.Request) {
 		// Slack API returns just the parent when there are no replies.
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"has_more": false,
 			"messages": []map[string]any{
@@ -86,7 +86,7 @@ func TestThreadList_NoReplies(t *testing.T) {
 func TestThreadList_ReadAlias(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.replies", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":       true,
 			"has_more": false,
 			"messages": []map[string]any{

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -147,7 +147,7 @@ func (c *UserInfoCmd) Run(cli *CLI) error {
 func userToMap(u slack.User) map[string]any {
 	data, _ := json.Marshal(u)
 	var m map[string]any
-	json.Unmarshal(data, &m)
+	_ = json.Unmarshal(data, &m)
 	return m
 }
 

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -109,20 +109,25 @@ func (c *UserInfoCmd) Run(cli *CLI) error {
 			continue
 		}
 
-		user, err := client.Bot().GetUserInfoContext(ctx, userID)
-		if err != nil {
-			errorCount++
-			if err := p.PrintItem(map[string]any{
-				"input":  input,
-				"error":  "user_not_found",
-				"detail": "No user matching '" + input + "'",
-			}); err != nil {
-				return err
+		// Try cached profile first, fall back to direct API call.
+		user, found, lookupErr := r.LookupUser(ctx, userID)
+		if lookupErr != nil || !found {
+			apiUser, err := client.Bot().GetUserInfoContext(ctx, userID)
+			if err != nil {
+				errorCount++
+				if err := p.PrintItem(map[string]any{
+					"input":  input,
+					"error":  "user_not_found",
+					"detail": "No user matching '" + input + "'",
+				}); err != nil {
+					return err
+				}
+				continue
 			}
-			continue
+			user = *apiUser
 		}
 
-		m := userToMap(*user)
+		m := userToMap(user)
 		m["input"] = input
 		if err := p.PrintItem(m); err != nil {
 			return err

--- a/cmd/user_test.go
+++ b/cmd/user_test.go
@@ -12,7 +12,7 @@ import (
 func TestUserList_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/users.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true,
 			"members": []map[string]any{
 				{"id": "U01", "name": "tammer", "real_name": "Tammer Saleh", "profile": map[string]any{"email": "tammer@example.com"}},
@@ -41,7 +41,7 @@ func TestUserList_MockAPI(t *testing.T) {
 func TestUserList_QueryFilter(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/users.list", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true,
 			"members": []map[string]any{
 				{"id": "U01", "name": "tammer", "real_name": "Tammer Saleh", "profile": map[string]any{"email": "tammer@example.com"}},
@@ -65,7 +65,7 @@ func TestUserList_QueryFilter(t *testing.T) {
 func TestUserInfo_MockAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/users.info", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true,
 			"user": map[string]any{
 				"id": "U01", "name": "tammer", "real_name": "Tammer Saleh",
@@ -96,13 +96,13 @@ func TestUserInfo_MockAPI(t *testing.T) {
 func TestUserInfo_ByEmail(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/users.lookupByEmail", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":   true,
 			"user": map[string]any{"id": "U01", "name": "tammer"},
 		})
 	})
 	mux.HandleFunc("/api/users.info", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":   true,
 			"user": map[string]any{"id": "U01", "name": "tammer", "real_name": "Tammer Saleh"},
 		})
@@ -127,15 +127,15 @@ func TestUserInfo_ByEmail(t *testing.T) {
 func TestUserInfo_PartialFailure_NoStderr(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/users.info", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		uid := r.FormValue("user")
 		if uid == "U01" {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":   true,
 				"user": map[string]any{"id": "U01", "name": "tammer"},
 			})
 		} else {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":    false,
 				"error": "user_not_found",
 			})
@@ -155,7 +155,7 @@ func TestUserInfo_PartialFailure_NoStderr(t *testing.T) {
 func TestUserInfo_NotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/users.info", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":    false,
 			"error": "user_not_found",
 		})

--- a/internal/auth/desktop_test.go
+++ b/internal/auth/desktop_test.go
@@ -150,7 +150,7 @@ func TestValidateDesktopCredentials_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
 		gotCookie = r.Header.Get("Cookie")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":      true,
 			"url":     "https://acme.slack.com/",
 			"team":    "Acme Corp",
@@ -182,7 +182,7 @@ func TestValidateDesktopCredentials_Success(t *testing.T) {
 
 func TestValidateDesktopCredentials_AuthFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":    false,
 			"error": "invalid_auth",
 		})

--- a/internal/resolve/channel.go
+++ b/internal/resolve/channel.go
@@ -128,7 +128,7 @@ func (r *Resolver) loadFileCache() (*channelFileCache, error) {
 		return nil, err
 	}
 
-	if time.Since(fc.UpdatedAt) > fileCacheTTL {
+	if time.Since(fc.UpdatedAt) > fileCacheTTL() {
 		return nil, nil
 	}
 

--- a/internal/resolve/channel_test.go
+++ b/internal/resolve/channel_test.go
@@ -231,9 +231,9 @@ func TestResolveChannel_FileCacheExpired(t *testing.T) {
 	cacheDir := t.TempDir()
 	teamID := "T123"
 
-	// Pre-populate expired file cache.
+	// Pre-populate expired file cache (older than 24h default TTL).
 	cache := channelFileCache{
-		UpdatedAt: time.Now().Add(-2 * time.Hour),
+		UpdatedAt: time.Now().Add(-25 * time.Hour),
 		Channels:  map[string]string{"stale-channel": "C888"},
 	}
 	data, _ := json.Marshal(cache)

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -1,16 +1,29 @@
 package resolve
 
 import (
+	"os"
 	"sync"
 	"time"
 
+	"github.com/slack-go/slack"
 	"github.com/tammersaleh/slack-cli/internal/api"
 )
 
 const (
-	memoryCacheTTL = 5 * time.Minute
-	fileCacheTTL   = 1 * time.Hour
+	memoryCacheTTL     = 5 * time.Minute
+	defaultFileCacheTTL = 24 * time.Hour
 )
+
+// fileCacheTTL returns the configured file cache TTL, checking
+// SLACK_CACHE_TTL first and falling back to 24h.
+func fileCacheTTL() time.Duration {
+	if v := os.Getenv("SLACK_CACHE_TTL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultFileCacheTTL
+}
 
 // Resolver resolves human-friendly channel names and user identifiers to Slack IDs.
 type Resolver struct {
@@ -21,11 +34,14 @@ type Resolver struct {
 	mu         sync.RWMutex
 	channels   map[string]string // name -> ID
 	channelsAt time.Time
+
+	users        map[string]slack.User // ID -> User
+	usersByEmail map[string]string     // email -> ID
+	usersAt      time.Time
 }
 
 // NewResolver creates a Resolver using the given API client. If teamID and
-// cacheDir are non-empty, a file-based channel cache is used to persist
-// lookups across invocations.
+// cacheDir are non-empty, file-based caches persist lookups across invocations.
 func NewResolver(client *api.Client, teamID, cacheDir string) *Resolver {
 	return &Resolver{client: client, teamID: teamID, cacheDir: cacheDir}
 }

--- a/internal/resolve/user.go
+++ b/internal/resolve/user.go
@@ -76,7 +76,9 @@ func (r *Resolver) ensureUserCache(ctx context.Context) error {
 	// Try file cache.
 	if fc, err := r.loadUserFileCache(); err == nil && fc != nil {
 		r.mu.Lock()
-		r.setUserMaps(fc.Users)
+		if r.users == nil || time.Since(r.usersAt) >= memoryCacheTTL {
+			r.setUserMaps(fc.Users)
+		}
 		r.mu.Unlock()
 		return nil
 	}
@@ -89,12 +91,11 @@ func (r *Resolver) ensureUserCache(ctx context.Context) error {
 // in-memory and file caches.
 func (r *Resolver) bulkLoadUsers(ctx context.Context) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// Re-check after acquiring write lock.
 	if r.users != nil && time.Since(r.usersAt) < memoryCacheTTL {
+		r.mu.Unlock()
 		return nil
 	}
+	r.mu.Unlock()
 
 	users, err := r.client.Bot().GetUsersContext(ctx)
 	if err != nil {
@@ -106,8 +107,10 @@ func (r *Resolver) bulkLoadUsers(ctx context.Context) error {
 		userMap[u.ID] = u
 	}
 
+	r.mu.Lock()
 	r.setUserMaps(userMap)
 	r.saveUserFileCache(userMap)
+	r.mu.Unlock()
 	return nil
 }
 

--- a/internal/resolve/user.go
+++ b/internal/resolve/user.go
@@ -2,21 +2,45 @@ package resolve
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
+
+	"github.com/slack-go/slack"
 )
 
 var userIDPattern = regexp.MustCompile(`^[UW][A-Z0-9]+$`)
 
+// userFileCache is the on-disk format for the user cache.
+type userFileCache struct {
+	UpdatedAt time.Time              `json:"updated_at"`
+	Users     map[string]slack.User  `json:"users"`
+}
+
 // ResolveUser resolves a user identifier to a Slack user ID.
-// Accepts user IDs (passthrough) and email addresses.
+// Accepts user IDs (passthrough) and email addresses. Email lookups
+// check the user cache first, falling back to the API.
 func (r *Resolver) ResolveUser(ctx context.Context, input string) (string, error) {
 	if userIDPattern.MatchString(input) {
 		return input, nil
 	}
 
 	if isEmail(input) {
+		// Try cache-backed email lookup first.
+		if err := r.ensureUserCache(ctx); err == nil {
+			r.mu.RLock()
+			id, ok := r.usersByEmail[strings.ToLower(input)]
+			r.mu.RUnlock()
+			if ok {
+				return id, nil
+			}
+		}
+
+		// Fall back to direct API lookup.
 		user, err := r.client.Bot().GetUserByEmailContext(ctx, input)
 		if err != nil {
 			return "", fmt.Errorf("resolving user %q: %w", input, err)
@@ -25,6 +49,131 @@ func (r *Resolver) ResolveUser(ctx context.Context, input string) (string, error
 	}
 
 	return "", fmt.Errorf("cannot resolve user %q: expected a user ID (U...) or email address", input)
+}
+
+// LookupUser returns the full cached profile for a user ID. It populates
+// the cache on first call by bulk-loading all users. Returns (user, found, error).
+func (r *Resolver) LookupUser(ctx context.Context, id string) (slack.User, bool, error) {
+	if err := r.ensureUserCache(ctx); err != nil {
+		return slack.User{}, false, err
+	}
+
+	r.mu.RLock()
+	user, found := r.users[id]
+	r.mu.RUnlock()
+	return user, found, nil
+}
+
+// ensureUserCache populates the user cache if it's empty or stale.
+func (r *Resolver) ensureUserCache(ctx context.Context) error {
+	r.mu.RLock()
+	if r.users != nil && time.Since(r.usersAt) < memoryCacheTTL {
+		r.mu.RUnlock()
+		return nil
+	}
+	r.mu.RUnlock()
+
+	// Try file cache.
+	if fc, err := r.loadUserFileCache(); err == nil && fc != nil {
+		r.mu.Lock()
+		r.setUserMaps(fc.Users)
+		r.mu.Unlock()
+		return nil
+	}
+
+	// Bulk-load from API.
+	return r.bulkLoadUsers(ctx)
+}
+
+// bulkLoadUsers fetches all users via users.list and populates both
+// in-memory and file caches.
+func (r *Resolver) bulkLoadUsers(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Re-check after acquiring write lock.
+	if r.users != nil && time.Since(r.usersAt) < memoryCacheTTL {
+		return nil
+	}
+
+	users, err := r.client.Bot().GetUsersContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	userMap := make(map[string]slack.User, len(users))
+	for _, u := range users {
+		userMap[u.ID] = u
+	}
+
+	r.setUserMaps(userMap)
+	r.saveUserFileCache(userMap)
+	return nil
+}
+
+// setUserMaps populates the in-memory user and email index maps.
+// Must be called with r.mu held.
+func (r *Resolver) setUserMaps(users map[string]slack.User) {
+	r.users = users
+	r.usersAt = time.Now()
+	r.usersByEmail = make(map[string]string, len(users))
+	for id, u := range users {
+		if u.Profile.Email != "" {
+			r.usersByEmail[strings.ToLower(u.Profile.Email)] = id
+		}
+	}
+}
+
+// loadUserFileCache reads the user file cache if it exists and is fresh.
+func (r *Resolver) loadUserFileCache() (*userFileCache, error) {
+	path := r.userCachePath()
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var fc userFileCache
+	if err := json.Unmarshal(data, &fc); err != nil {
+		return nil, err
+	}
+
+	if time.Since(fc.UpdatedAt) > fileCacheTTL() {
+		return nil, nil
+	}
+
+	return &fc, nil
+}
+
+// saveUserFileCache writes the user map to disk.
+func (r *Resolver) saveUserFileCache(users map[string]slack.User) {
+	path := r.userCachePath()
+	if path == "" {
+		return
+	}
+
+	fc := userFileCache{
+		UpdatedAt: time.Now(),
+		Users:     users,
+	}
+	data, err := json.Marshal(fc)
+	if err != nil {
+		return
+	}
+
+	_ = os.MkdirAll(filepath.Dir(path), 0700)
+	_ = os.WriteFile(path, data, 0600)
+}
+
+// userCachePath returns the file cache path, or "" if caching is disabled.
+func (r *Resolver) userCachePath() string {
+	if r.teamID == "" || r.cacheDir == "" {
+		return ""
+	}
+	return filepath.Join(r.cacheDir, "users-"+r.teamID+".json")
 }
 
 func isEmail(s string) bool {

--- a/internal/resolve/user_cache_test.go
+++ b/internal/resolve/user_cache_test.go
@@ -1,0 +1,292 @@
+package resolve
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+// usersListHandler returns a mock handler that serves a users.list response.
+func usersListHandler(t *testing.T, users []slack.User) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/users.list" {
+			http.Error(w, "not found", 404)
+			return
+		}
+		resp := struct {
+			OK      bool         `json:"ok"`
+			Members []slack.User `json:"members"`
+		}{OK: true, Members: users}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func testUsers() []slack.User {
+	return []slack.User{
+		{ID: "U001", Name: "alice", RealName: "Alice Smith", Profile: slack.UserProfile{Email: "alice@example.com"}},
+		{ID: "U002", Name: "bob", RealName: "Bob Jones", Profile: slack.UserProfile{Email: "bob@example.com"}},
+		{ID: "U003", Name: "charlie", RealName: "Charlie Brown", Profile: slack.UserProfile{Email: ""}},
+	}
+}
+
+func TestLookupUser_BulkLoad(t *testing.T) {
+	calls := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		usersListHandler(t, testUsers())(w, r)
+	}))
+
+	r := NewResolver(client, "T123", t.TempDir())
+
+	user, found, err := r.LookupUser(context.Background(), "U001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected user to be found")
+	}
+	if user.Name != "alice" {
+		t.Errorf("got name=%q, want %q", user.Name, "alice")
+	}
+	if calls != 1 {
+		t.Errorf("got %d API calls, want 1", calls)
+	}
+}
+
+func TestLookupUser_CacheReuse(t *testing.T) {
+	calls := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		usersListHandler(t, testUsers())(w, r)
+	}))
+
+	r := NewResolver(client, "T123", t.TempDir())
+	ctx := context.Background()
+
+	// First lookup triggers bulk load.
+	_, _, err := r.LookupUser(ctx, "U001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second lookup should use cache.
+	user, found, err := r.LookupUser(ctx, "U002")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected bob to be found from cache")
+	}
+	if user.Name != "bob" {
+		t.Errorf("got name=%q, want %q", user.Name, "bob")
+	}
+	if calls != 1 {
+		t.Errorf("got %d API calls, want 1 (cache should be reused)", calls)
+	}
+}
+
+func TestLookupUser_NotFound(t *testing.T) {
+	client := newTestClient(t, usersListHandler(t, testUsers()))
+	r := NewResolver(client, "T123", t.TempDir())
+
+	_, found, err := r.LookupUser(context.Background(), "U999")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Error("expected user not to be found")
+	}
+}
+
+func TestResolveUser_EmailFromCache(t *testing.T) {
+	calls := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path == "/api/users.list" {
+			usersListHandler(t, testUsers())(w, r)
+			return
+		}
+		t.Fatalf("unexpected API call to %s (email should resolve from cache)", r.URL.Path)
+	}))
+
+	r := NewResolver(client, "T123", t.TempDir())
+	id, err := r.ResolveUser(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "U001" {
+		t.Errorf("got %q, want %q", id, "U001")
+	}
+	if calls != 1 {
+		t.Errorf("got %d API calls, want 1 (users.list only)", calls)
+	}
+}
+
+func TestResolveUser_EmailNotInCache(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/users.list" {
+			usersListHandler(t, testUsers())(w, r)
+			return
+		}
+		if r.URL.Path == "/api/users.lookupByEmail" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":    false,
+				"error": "users_not_found",
+			})
+			return
+		}
+		t.Fatalf("unexpected API call to %s", r.URL.Path)
+	}))
+
+	r := NewResolver(client, "T123", t.TempDir())
+	_, err := r.ResolveUser(context.Background(), "unknown@example.com")
+	if err == nil {
+		t.Error("expected error for unknown email")
+	}
+}
+
+func TestLookupUser_FileCacheHit(t *testing.T) {
+	cacheDir := t.TempDir()
+	teamID := "T123"
+
+	// Pre-populate file cache.
+	users := testUsers()
+	cache := userFileCache{
+		UpdatedAt: time.Now(),
+		Users:     make(map[string]slack.User),
+	}
+	for _, u := range users {
+		cache.Users[u.ID] = u
+	}
+	data, _ := json.Marshal(cache)
+	cacheFile := filepath.Join(cacheDir, "users-"+teamID+".json")
+	if err := os.WriteFile(cacheFile, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Client that should never be called.
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should not be called when file cache is fresh")
+	}))
+
+	r := NewResolver(client, teamID, cacheDir)
+	user, found, err := r.LookupUser(context.Background(), "U001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected user to be found from file cache")
+	}
+	if user.Name != "alice" {
+		t.Errorf("got name=%q, want %q", user.Name, "alice")
+	}
+}
+
+func TestLookupUser_FileCacheExpired(t *testing.T) {
+	cacheDir := t.TempDir()
+	teamID := "T123"
+
+	// Pre-populate expired file cache.
+	cache := userFileCache{
+		UpdatedAt: time.Now().Add(-25 * time.Hour),
+		Users:     map[string]slack.User{"U001": {ID: "U001", Name: "stale"}},
+	}
+	data, _ := json.Marshal(cache)
+	cacheFile := filepath.Join(cacheDir, "users-"+teamID+".json")
+	if err := os.WriteFile(cacheFile, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		usersListHandler(t, testUsers())(w, r)
+	}))
+
+	r := NewResolver(client, teamID, cacheDir)
+	user, found, err := r.LookupUser(context.Background(), "U001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected user to be found after refetch")
+	}
+	if user.Name != "alice" {
+		t.Errorf("got name=%q, want %q (should be fresh, not stale)", user.Name, "alice")
+	}
+	if calls != 1 {
+		t.Errorf("got %d API calls, want 1 (should refetch after expired cache)", calls)
+	}
+}
+
+func TestLookupUser_FileCacheWritten(t *testing.T) {
+	cacheDir := t.TempDir()
+	teamID := "T123"
+
+	client := newTestClient(t, usersListHandler(t, testUsers()))
+	r := NewResolver(client, teamID, cacheDir)
+
+	// Trigger bulk load.
+	_, _, err := r.LookupUser(context.Background(), "U001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify file cache was written.
+	cacheFile := filepath.Join(cacheDir, "users-"+teamID+".json")
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("file cache not written: %v", err)
+	}
+	var fc userFileCache
+	if err := json.Unmarshal(data, &fc); err != nil {
+		t.Fatalf("invalid file cache: %v", err)
+	}
+	if len(fc.Users) != 3 {
+		t.Errorf("expected 3 users in file cache, got %d", len(fc.Users))
+	}
+	if fc.Users["U001"].Name != "alice" {
+		t.Errorf("expected alice in file cache, got %q", fc.Users["U001"].Name)
+	}
+}
+
+func TestResolveUser_EmailFromFileCacheIndex(t *testing.T) {
+	cacheDir := t.TempDir()
+	teamID := "T123"
+
+	// Pre-populate file cache.
+	users := testUsers()
+	cache := userFileCache{
+		UpdatedAt: time.Now(),
+		Users:     make(map[string]slack.User),
+	}
+	for _, u := range users {
+		cache.Users[u.ID] = u
+	}
+	data, _ := json.Marshal(cache)
+	cacheFile := filepath.Join(cacheDir, "users-"+teamID+".json")
+	if err := os.WriteFile(cacheFile, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Client that should never be called.
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should not be called for cached email resolution")
+	}))
+
+	r := NewResolver(client, teamID, cacheDir)
+	id, err := r.ResolveUser(context.Background(), "bob@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "U002" {
+		t.Errorf("got %q, want %q", id, "U002")
+	}
+}

--- a/internal/resolve/user_test.go
+++ b/internal/resolve/user_test.go
@@ -32,13 +32,17 @@ func TestResolveUser_IDPassthrough(t *testing.T) {
 	}
 }
 
-func TestResolveUser_Email(t *testing.T) {
-	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/users.lookupByEmail" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-			http.Error(w, "not found", 404)
-			return
-		}
+func TestResolveUser_EmailFallback(t *testing.T) {
+	// When the user cache bulk-load fails (e.g. no users.list handler),
+	// email resolution falls back to users.lookupByEmail.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/users.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"members": []map[string]any{},
+		})
+	})
+	mux.HandleFunc("/api/users.lookupByEmail", func(w http.ResponseWriter, r *http.Request) {
 		email := r.FormValue("email")
 		if email != "tammer@example.com" {
 			t.Errorf("got email=%q, want %q", email, "tammer@example.com")
@@ -50,7 +54,8 @@ func TestResolveUser_Email(t *testing.T) {
 				"name": "tammer",
 			},
 		})
-	}))
+	})
+	client := newTestClient(t, mux)
 
 	r := NewResolver(client, "", "")
 	id, err := r.ResolveUser(context.Background(), "tammer@example.com")
@@ -63,12 +68,20 @@ func TestResolveUser_Email(t *testing.T) {
 }
 
 func TestResolveUser_EmailNotFound(t *testing.T) {
-	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/users.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"members": []map[string]any{},
+		})
+	})
+	mux.HandleFunc("/api/users.lookupByEmail", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":    false,
 			"error": "users_not_found",
 		})
-	}))
+	})
+	client := newTestClient(t, mux)
 
 	r := NewResolver(client, "", "")
 	_, err := r.ResolveUser(context.Background(), "nobody@example.com")

--- a/internal/resolve/user_test.go
+++ b/internal/resolve/user_test.go
@@ -33,8 +33,8 @@ func TestResolveUser_IDPassthrough(t *testing.T) {
 }
 
 func TestResolveUser_EmailFallback(t *testing.T) {
-	// When the user cache bulk-load fails (e.g. no users.list handler),
-	// email resolution falls back to users.lookupByEmail.
+	// When the email is not in the bulk-loaded cache,
+	// resolution falls back to users.lookupByEmail.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/users.list", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/main.go
+++ b/main.go
@@ -31,12 +31,12 @@ func main() {
 
 	var oErr *output.Error
 	if errors.As(err, &oErr) {
-		json.NewEncoder(os.Stderr).Encode(oErr)
+		_ = json.NewEncoder(os.Stderr).Encode(oErr)
 		os.Exit(oErr.Code)
 	}
 
 	// Unstructured errors: wrap in JSON for consistency.
-	json.NewEncoder(os.Stderr).Encode(map[string]string{
+	_ = json.NewEncoder(os.Stderr).Encode(map[string]string{
 		"error":  "general_error",
 		"detail": err.Error(),
 	})


### PR DESCRIPTION
## Summary

- Add three-tier user cache: in-memory (5min) -> file (24h) -> bulk-load via `users.list`
- `LookupUser(id)` returns cached profiles; `ResolveUser(email)` checks email index from cache
- `UserInfoCmd` tries cached profiles before per-user API calls
- Bump file cache TTL from 1h to 24h for both channels and users (matches MCP behavior)
- Add `SLACK_CACHE_TTL` env var for configurable TTL (Go duration format)
- Covers PLAN.md items #3 (user caching) and #4 (channel cache TTL bump)

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Bulk-load, cache reuse, file cache hit/expired, email resolution from cache
- [x] Existing channel cache tests updated for 24h TTL
- [x] Email fallback to `lookupByEmail` when not in cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)