### PR TITLE
feat: saved list and counts commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ type CLI struct {
 	Auth     AuthCmd     `cmd:"" help:"Manage authentication."`
 	Channel  ChannelCmd  `cmd:"" help:"Read channel information."`
 	Message  MessageCmd  `cmd:"" help:"Read messages."`
+	Saved    SavedCmd    `cmd:"" help:"Saved-for-later items (requires session token)."`
 	Search   SearchCmd   `cmd:"" help:"Search messages and files."`
 	Thread   ThreadCmd   `cmd:"" help:"Read thread replies."`
 	User     UserCmd     `cmd:"" help:"Read user information."`

--- a/cmd/saved.go
+++ b/cmd/saved.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/tammersaleh/slack-cli/internal/api"
+	"github.com/tammersaleh/slack-cli/internal/output"
+)
+
+type SavedCmd struct {
+	List   SavedListCmd   `cmd:"" help:"List saved-for-later items."`
+	Counts SavedCountsCmd `cmd:"" help:"Show saved item counts."`
+}
+
+type SavedListCmd struct {
+	Limit            int    `help:"Page size." default:"20"`
+	Cursor           string `help:"Continue from previous page."`
+	All              bool   `help:"Fetch all pages."`
+	Enrich           bool   `help:"Fetch message text and channel names for each item."`
+	IncludeCompleted bool   `help:"Include completed items."`
+}
+
+type SavedCountsCmd struct{}
+
+// savedItem is a single item from the saved.list response.
+type savedItem struct {
+	ItemID        string `json:"item_id"`
+	TS            string `json:"ts"`
+	DateCreated   int64  `json:"date_created"`
+	DateDue       int64  `json:"date_due,omitempty"`
+	DateCompleted int64  `json:"date_completed,omitempty"`
+	TodoState     string `json:"todo_state"`
+}
+
+// savedListResponse is the parsed saved.list API response.
+type savedListResponse struct {
+	SavedItems       []savedItem    `json:"saved_items"`
+	Counts           map[string]any `json:"counts"`
+	ResponseMetadata struct {
+		NextCursor string `json:"next_cursor"`
+	} `json:"response_metadata"`
+}
+
+func (c *SavedListCmd) Run(cli *CLI) error {
+	if c.All && c.Cursor != "" {
+		return &output.Error{Err: "invalid_input", Detail: "--all and --cursor are mutually exclusive", Code: output.ExitGeneral}
+	}
+
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	if err := requireSessionToken(client); err != nil {
+		return err
+	}
+
+	p := cli.NewPrinter()
+	ctx := context.Background()
+
+	limit := c.Limit
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+
+	cursor := c.Cursor
+
+	for {
+		body := map[string]any{
+			"count": limit,
+		}
+		if c.IncludeCompleted {
+			body["include_completed"] = true
+		}
+		if cursor != "" {
+			body["cursor"] = cursor
+		}
+
+		data, err := client.PostInternal(ctx, "saved.list", body)
+		if err != nil {
+			return cli.ClassifyError(err)
+		}
+
+		var resp savedListResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return &output.Error{Err: "parse_error", Detail: "Failed to parse saved.list response", Code: output.ExitGeneral}
+		}
+
+		var enrichment map[string]enrichedData
+		if c.Enrich && len(resp.SavedItems) > 0 {
+			enrichment = enrichItems(ctx, client, resp.SavedItems)
+		}
+
+		for _, item := range resp.SavedItems {
+			m := formatSavedItem(item)
+			if enrichment != nil {
+				key := item.ItemID + ":" + item.TS
+				if e, ok := enrichment[key]; ok {
+					if e.ChannelName != "" {
+						m["channel_name"] = e.ChannelName
+					}
+					if e.Text != "" {
+						m["text"] = e.Text
+					}
+					if e.FromUser != "" {
+						m["from_user"] = e.FromUser
+					}
+				}
+			}
+			if err := p.PrintItem(m); err != nil {
+				return err
+			}
+		}
+
+		nextCursor := resp.ResponseMetadata.NextCursor
+		if !c.All || nextCursor == "" {
+			return p.PrintMeta(output.Meta{
+				HasMore:    nextCursor != "",
+				NextCursor: nextCursor,
+			})
+		}
+		cursor = nextCursor
+	}
+}
+
+func (c *SavedCountsCmd) Run(cli *CLI) error {
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	if err := requireSessionToken(client); err != nil {
+		return err
+	}
+
+	p := cli.NewPrinter()
+	ctx := context.Background()
+
+	data, err := client.PostInternal(ctx, "saved.list", map[string]any{
+		"count": 1,
+	})
+	if err != nil {
+		return cli.ClassifyError(err)
+	}
+
+	var resp savedListResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return &output.Error{Err: "parse_error", Detail: "Failed to parse saved.list response", Code: output.ExitGeneral}
+	}
+
+	if err := p.PrintItem(resp.Counts); err != nil {
+		return err
+	}
+	return p.PrintMeta(output.Meta{})
+}
+
+func requireSessionToken(client *api.Client) error {
+	if !strings.HasPrefix(client.Token(), "xoxc-") {
+		return &output.Error{
+			Err:    "session_token_required",
+			Detail: "saved commands require a session token (xoxc-)",
+			Hint:   "Run 'slack auth login --desktop' to authenticate with a session token",
+			Code:   output.ExitAuth,
+		}
+	}
+	return nil
+}
+
+func formatSavedItem(item savedItem) map[string]any {
+	tsNoDot := strings.ReplaceAll(item.TS, ".", "")
+	permalink := fmt.Sprintf("https://slack.com/archives/%s/p%s", item.ItemID, tsNoDot)
+
+	m := map[string]any{
+		"channel_id": item.ItemID,
+		"message_ts": item.TS,
+		"saved_at":   time.Unix(item.DateCreated, 0).UTC().Format(time.RFC3339),
+		"todo_state": item.TodoState,
+		"permalink":  permalink,
+	}
+	if item.DateDue > 0 {
+		m["due"] = time.Unix(item.DateDue, 0).UTC().Format(time.RFC3339)
+	}
+	if item.DateCompleted > 0 {
+		m["completed_at"] = time.Unix(item.DateCompleted, 0).UTC().Format(time.RFC3339)
+	}
+	return m
+}
+
+// enrichedData holds message text and channel name fetched per saved item.
+type enrichedData struct {
+	Text        string
+	FromUser    string
+	ChannelName string
+}
+
+const enrichConcurrency = 10
+
+// enrichItems fetches message text and channel names concurrently.
+func enrichItems(ctx context.Context, client *api.Client, items []savedItem) map[string]enrichedData {
+	result := make(map[string]enrichedData)
+	var mu sync.Mutex
+	sem := make(chan struct{}, enrichConcurrency)
+	var wg sync.WaitGroup
+
+	for _, item := range items {
+		wg.Add(1)
+		go func(item savedItem) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			key := item.ItemID + ":" + item.TS
+			var ed enrichedData
+
+			// Fetch message text.
+			resp, err := client.Bot().GetConversationHistoryContext(ctx, &slack.GetConversationHistoryParameters{
+				ChannelID: item.ItemID,
+				Latest:    item.TS,
+				Inclusive: true,
+				Limit:     1,
+			})
+			if err == nil && len(resp.Messages) > 0 {
+				ed.Text = resp.Messages[0].Text
+				ed.FromUser = resp.Messages[0].User
+			}
+
+			// Fetch channel name.
+			ch, err := client.Bot().GetConversationInfoContext(ctx, &slack.GetConversationInfoInput{
+				ChannelID: item.ItemID,
+			})
+			if err == nil && ch != nil {
+				ed.ChannelName = ch.Name
+			}
+
+			mu.Lock()
+			result[key] = ed
+			mu.Unlock()
+		}(item)
+	}
+
+	wg.Wait()
+	return result
+}

--- a/cmd/saved.go
+++ b/cmd/saved.go
@@ -212,7 +212,11 @@ func enrichItems(ctx context.Context, client *api.Client, items []savedItem) map
 		wg.Add(1)
 		go func(item savedItem) {
 			defer wg.Done()
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 			defer func() { <-sem }()
 
 			key := item.ItemID + ":" + item.TS

--- a/cmd/saved_test.go
+++ b/cmd/saved_test.go
@@ -1,0 +1,258 @@
+package cmd_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/tammersaleh/slack-cli/cmd"
+)
+
+// runWithMockSession is like runWithMock but uses an xoxc- session token.
+func runWithMockSession(t *testing.T, handler http.Handler, args ...string) (string, error) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	t.Setenv("SLACK_TOKEN", "xoxc-test")
+	t.Setenv("SLACK_API_URL", srv.URL+"/api/")
+
+	var cli cmd.CLI
+	var outBuf, errBuf bytes.Buffer
+
+	parser, err := kong.New(&cli,
+		kong.Name("slack"),
+		kong.Exit(func(int) {}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kctx, err := parser.Parse(args)
+	if err != nil {
+		return "", err
+	}
+
+	cli.SetOutput(&outBuf, &errBuf)
+	runErr := kctx.Run(&cli)
+	return outBuf.String(), runErr
+}
+
+func savedListHandler(t *testing.T, items []map[string]any, counts map[string]any, nextCursor string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/saved.list" {
+			http.Error(w, "not found", 404)
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+
+		resp := map[string]any{
+			"ok":          true,
+			"saved_items": items,
+			"counts":      counts,
+			"response_metadata": map[string]string{
+				"next_cursor": nextCursor,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func TestSavedList_Basic(t *testing.T) {
+	items := []map[string]any{
+		{
+			"item_id":      "C01ABC",
+			"ts":           "1709251200.000100",
+			"date_created": 1709251200,
+			"todo_state":   "uncompleted",
+		},
+		{
+			"item_id":      "C02DEF",
+			"ts":           "1709164800.000050",
+			"date_created": 1709164800,
+			"todo_state":   "uncompleted",
+		},
+	}
+	counts := map[string]any{"uncompleted": 2, "completed": 0, "total": 2}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/saved.list", savedListHandler(t, items, counts, ""))
+
+	out, err := runWithMockSession(t, mux, "saved", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (2 items + meta), got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["channel_id"] != "C01ABC" {
+		t.Errorf("expected channel_id='C01ABC', got %q", item["channel_id"])
+	}
+	if item["message_ts"] != "1709251200.000100" {
+		t.Errorf("expected message_ts, got %q", item["message_ts"])
+	}
+	if item["permalink"] == nil || item["permalink"] == "" {
+		t.Error("expected non-empty permalink")
+	}
+}
+
+func TestSavedList_Pagination(t *testing.T) {
+	items := []map[string]any{
+		{"item_id": "C01ABC", "ts": "1.1", "date_created": 1709251200, "todo_state": "uncompleted"},
+	}
+	counts := map[string]any{"uncompleted": 5, "total": 5}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/saved.list", savedListHandler(t, items, counts, "nextpage"))
+
+	out, err := runWithMockSession(t, mux, "saved", "list", "--limit", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+
+	meta := parseJSON(t, lines[1])
+	m := meta["_meta"].(map[string]any)
+	if m["has_more"] != true {
+		t.Error("expected has_more=true")
+	}
+	if m["next_cursor"] != "nextpage" {
+		t.Errorf("expected next_cursor='nextpage', got %q", m["next_cursor"])
+	}
+}
+
+func TestSavedList_SessionTokenRequired(t *testing.T) {
+	// With a regular xoxb- token, saved.list should fail with session_token_required.
+	mux := http.NewServeMux()
+	// No handler needed - should fail before making the call.
+
+	_, err := runWithMock(t, mux, "saved", "list")
+	if err == nil {
+		t.Fatal("expected error for non-session token")
+	}
+}
+
+func TestSavedCounts(t *testing.T) {
+	items := []map[string]any{
+		{"item_id": "C01ABC", "ts": "1.1", "date_created": 1709251200, "todo_state": "uncompleted"},
+	}
+	counts := map[string]any{
+		"uncompleted": 12,
+		"overdue":     2,
+		"completed":   45,
+		"total":       59,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/saved.list", savedListHandler(t, items, counts, ""))
+
+	out, err := runWithMockSession(t, mux, "saved", "counts")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (counts + meta), got %d:\n%s", len(lines), out)
+	}
+
+	c := parseJSON(t, lines[0])
+	if c["uncompleted"] != float64(12) {
+		t.Errorf("expected uncompleted=12, got %v", c["uncompleted"])
+	}
+	if c["total"] != float64(59) {
+		t.Errorf("expected total=59, got %v", c["total"])
+	}
+}
+
+func TestSavedList_Enrich(t *testing.T) {
+	items := []map[string]any{
+		{"item_id": "C01ABC", "ts": "1709251200.000100", "date_created": 1709251200, "todo_state": "uncompleted"},
+	}
+	counts := map[string]any{"uncompleted": 1, "total": 1}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/saved.list", savedListHandler(t, items, counts, ""))
+	mux.HandleFunc("/api/conversations.history", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"messages": []map[string]any{
+				{"text": "Hello world", "user": "U01XYZ", "ts": "1709251200.000100"},
+			},
+		})
+	})
+	mux.HandleFunc("/api/conversations.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"channel": map[string]any{
+				"id":   "C01ABC",
+				"name": "general",
+			},
+		})
+	})
+
+	out, err := runWithMockSession(t, mux, "saved", "list", "--enrich")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["text"] != "Hello world" {
+		t.Errorf("expected text='Hello world', got %q", item["text"])
+	}
+	if item["channel_name"] != "general" {
+		t.Errorf("expected channel_name='general', got %q", item["channel_name"])
+	}
+	if item["from_user"] != "U01XYZ" {
+		t.Errorf("expected from_user='U01XYZ', got %q", item["from_user"])
+	}
+}
+
+func TestSavedList_IncludeCompleted(t *testing.T) {
+	gotIncludeCompleted := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/saved.list", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if ic, ok := req["include_completed"]; ok && ic == true {
+			gotIncludeCompleted = true
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":                true,
+			"saved_items":       []map[string]any{},
+			"counts":            map[string]any{},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		})
+	})
+
+	_, err := runWithMockSession(t, mux, "saved", "list", "--include-completed")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !gotIncludeCompleted {
+		t.Error("expected include_completed=true in request body")
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,16 +1,24 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/slack-go/slack"
 )
 
 // Client wraps slack-go with configured retry and optional user token.
 type Client struct {
-	bot  *slack.Client
-	user *slack.Client
+	bot        *slack.Client
+	user       *slack.Client
+	httpClient *http.Client
+	apiURL     string
+	token      string
 }
 
 // Option configures a Client.
@@ -56,16 +64,29 @@ func New(botToken string, opts ...Option) *Client {
 		o(cfg)
 	}
 
+	var httpCl *http.Client
+	if cfg.cookie != "" {
+		httpCl = slackHTTPClient(cfg.cookie, cfg.tlsCAs)
+	}
+
 	var botOpts []slack.Option
 	if cfg.apiURL != "" {
 		botOpts = append(botOpts, slack.OptionAPIURL(cfg.apiURL))
 	}
-	if cfg.cookie != "" {
-		botOpts = append(botOpts, slack.OptionHTTPClient(slackHTTPClient(cfg.cookie, cfg.tlsCAs)))
+	if httpCl != nil {
+		botOpts = append(botOpts, slack.OptionHTTPClient(httpCl))
+	}
+
+	apiURL := "https://slack.com/api/"
+	if cfg.apiURL != "" {
+		apiURL = cfg.apiURL
 	}
 
 	c := &Client{
-		bot: slack.New(botToken, botOpts...),
+		bot:        slack.New(botToken, botOpts...),
+		httpClient: httpCl,
+		apiURL:     apiURL,
+		token:      botToken,
 	}
 
 	if cfg.userToken != "" {
@@ -86,8 +107,60 @@ func New(botToken string, opts ...Option) *Client {
 // Bot returns the bot token Slack client.
 func (c *Client) Bot() *slack.Client { return c.bot }
 
+// Token returns the primary token used by this client.
+func (c *Client) Token() string { return c.token }
+
 // User returns the user token Slack client, or nil if no user token was provided.
 func (c *Client) User() *slack.Client { return c.user }
+
+// PostInternal calls an internal Slack API method via raw HTTP POST with
+// a JSON body. The token is included in the request body. Returns the raw
+// JSON response body. Returns an error if the response has ok:false.
+func (c *Client) PostInternal(ctx context.Context, method string, body map[string]any) (json.RawMessage, error) {
+	body["token"] = c.token
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling request: %w", err)
+	}
+
+	url := c.apiURL + method
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	client := c.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	var envelope struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+	if !envelope.OK {
+		return nil, slack.SlackErrorResponse{Err: envelope.Error}
+	}
+
+	return json.RawMessage(data), nil
+}
 
 // AuthTestResult contains validated token metadata.
 type AuthTestResult struct {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -117,9 +117,14 @@ func (c *Client) User() *slack.Client { return c.user }
 // a JSON body. The token is included in the request body. Returns the raw
 // JSON response body. Returns an error if the response has ok:false.
 func (c *Client) PostInternal(ctx context.Context, method string, body map[string]any) (json.RawMessage, error) {
-	body["token"] = c.token
+	// Clone to avoid mutating the caller's map.
+	out := make(map[string]any, len(body)+1)
+	for k, v := range body {
+		out[k] = v
+	}
+	out["token"] = c.token
 
-	payload, err := json.Marshal(body)
+	payload, err := json.Marshal(out)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling request: %w", err)
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -184,3 +184,82 @@ func TestAuthTest_Failure(t *testing.T) {
 		t.Error("expected error for invalid auth")
 	}
 }
+
+func TestPostInternal_Success(t *testing.T) {
+	var gotContentType, gotAuth string
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":   true,
+			"data": "test-value",
+		})
+	}))
+	defer srv.Close()
+
+	c := New("xoxc-test-token", WithAPIURL(srv.URL+"/api/"))
+	data, err := c.PostInternal(context.Background(), "saved.list", map[string]any{
+		"count": 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotContentType != "application/json; charset=utf-8" {
+		t.Errorf("expected JSON content-type, got %q", gotContentType)
+	}
+	if gotAuth != "Bearer xoxc-test-token" {
+		t.Errorf("expected Bearer auth, got %q", gotAuth)
+	}
+	if gotBody["token"] != "xoxc-test-token" {
+		t.Errorf("expected token in body, got %v", gotBody["token"])
+	}
+	if gotBody["count"] != float64(20) {
+		t.Errorf("expected count=20 in body, got %v", gotBody["count"])
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["data"] != "test-value" {
+		t.Errorf("expected data='test-value', got %v", resp["data"])
+	}
+}
+
+func TestPostInternal_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "not_authed",
+		})
+	}))
+	defer srv.Close()
+
+	c := New("xoxc-test", WithAPIURL(srv.URL+"/api/"))
+	_, err := c.PostInternal(context.Background(), "saved.list", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for ok:false response")
+	}
+}
+
+func TestPostInternal_DoesNotMutateInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer srv.Close()
+
+	c := New("xoxc-test", WithAPIURL(srv.URL+"/api/"))
+	body := map[string]any{"count": 10}
+	_, err := c.PostInternal(context.Background(), "saved.list", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, hasToken := body["token"]; hasToken {
+		t.Error("PostInternal should not mutate the input map")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `PostInternal` to `api.Client` for raw HTTP calls to internal Slack APIs
- Add `slack saved list` with pagination, enrichment, --include-completed
- Add `slack saved counts` for saved item summary
- Session token (`xoxc-`) validation with helpful error message
- Concurrent enrichment via goroutines + semaphore (10 concurrent)
- Replaces `~/dotfiles/public/.claude/skills/slack-saved-items/` Python skill

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] Basic list, pagination, session token validation, counts, enrichment, --include-completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)