### PR TITLE
feat: add message post command

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -15,6 +15,7 @@ type MessageCmd struct {
 	List      MessageListCmd      `cmd:"" aliases:"read" help:"List messages in a channel."`
 	Get       MessageGetCmd       `cmd:"" help:"Get specific messages by timestamp."`
 	Permalink MessagePermalinkCmd `cmd:"" help:"Get permalinks for messages."`
+	Post      MessagePostCmd      `cmd:"" help:"Post a message to a channel."`
 }
 
 type MessageListCmd struct {

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +19,18 @@ type MessagePostCmd struct {
 }
 
 func (c *MessagePostCmd) Run(cli *CLI) error {
+	if c.Text != "" && c.Stdin {
+		return &output.Error{Err: "invalid_input", Detail: "--text and --stdin are mutually exclusive", Code: output.ExitGeneral}
+	}
+
 	text := c.Text
 	if c.Stdin {
-		data, err := io.ReadAll(os.Stdin)
+		in := cli.Stdin()
+		data, err := io.ReadAll(in)
 		if err != nil {
 			return &output.Error{Err: "stdin_error", Detail: err.Error(), Code: output.ExitGeneral}
 		}
-		text = strings.TrimRight(string(data), "\n")
+		text = strings.TrimRight(string(data), "\r\n")
 	}
 
 	if text == "" {

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/tammersaleh/slack-cli/internal/output"
+)
+
+type MessagePostCmd struct {
+	Channel string `arg:"" required:"" help:"Channel ID or name."`
+	Text    string `help:"Message text."`
+	Stdin   bool   `help:"Read message text from stdin."`
+	Thread  string `help:"Thread timestamp to reply to."`
+}
+
+func (c *MessagePostCmd) Run(cli *CLI) error {
+	text := c.Text
+	if c.Stdin {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return &output.Error{Err: "stdin_error", Detail: err.Error(), Code: output.ExitGeneral}
+		}
+		text = strings.TrimRight(string(data), "\n")
+	}
+
+	if text == "" {
+		return &output.Error{Err: "missing_text", Detail: "Provide --text or --stdin", Code: output.ExitGeneral}
+	}
+
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	p := cli.NewPrinter()
+	r := cli.NewResolver(client)
+	ctx := context.Background()
+
+	channelID, err := r.ResolveChannel(ctx, c.Channel)
+	if err != nil {
+		return &output.Error{Err: "channel_not_found", Detail: "No channel matching '" + c.Channel + "'", Code: output.ExitGeneral}
+	}
+
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(text, false),
+	}
+	if c.Thread != "" {
+		opts = append(opts, slack.MsgOptionTS(c.Thread))
+	}
+
+	respChannel, respTS, err := client.Bot().PostMessageContext(ctx, channelID, opts...)
+	if err != nil {
+		return cli.ClassifyError(err)
+	}
+
+	// Parse timestamp for ISO format.
+	tsISO := ""
+	if parts := strings.SplitN(respTS, ".", 2); len(parts) > 0 {
+		if epoch, err := strconv.ParseInt(parts[0], 10, 64); err == nil {
+			tsISO = time.Unix(epoch, 0).UTC().Format(time.RFC3339)
+		}
+	}
+
+	if err := p.PrintItem(map[string]any{
+		"channel": respChannel,
+		"ts":      respTS,
+		"ts_iso":  tsISO,
+	}); err != nil {
+		return err
+	}
+	return p.PrintMeta(output.Meta{})
+}

--- a/cmd/post_test.go
+++ b/cmd/post_test.go
@@ -1,9 +1,15 @@
 package cmd_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/tammersaleh/slack-cli/cmd"
 )
 
 func TestMessagePost_Text(t *testing.T) {
@@ -111,9 +117,23 @@ func TestMessagePost_ChannelResolution(t *testing.T) {
 
 func TestMessagePost_MissingText(t *testing.T) {
 	mux := http.NewServeMux()
-	_, err := runWithMock(t, mux, "message", "post", "C01ABC")
-	if err == nil {
+	r := runWithMockFull(t, mux, "message", "post", "C01ABC")
+	if r.err == nil {
 		t.Fatal("expected error when no --text or --stdin")
+	}
+	if !strings.Contains(r.err.Error(), "missing_text") {
+		t.Errorf("expected missing_text error, got %v", r.err)
+	}
+}
+
+func TestMessagePost_TextAndStdinExclusive(t *testing.T) {
+	mux := http.NewServeMux()
+	r := runWithMockFull(t, mux, "message", "post", "C01ABC", "--text", "foo", "--stdin")
+	if r.err == nil {
+		t.Fatal("expected error for --text and --stdin together")
+	}
+	if !strings.Contains(r.err.Error(), "invalid_input") {
+		t.Errorf("expected invalid_input error, got %v", r.err)
 	}
 }
 
@@ -129,5 +149,87 @@ func TestMessagePost_APIError(t *testing.T) {
 	_, err := runWithMock(t, mux, "message", "post", "C01ABC", "--text", "hello")
 	if err == nil {
 		t.Fatal("expected error for not_authed")
+	}
+}
+
+func TestMessagePost_Stdin(t *testing.T) {
+	var gotText string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotText = r.FormValue("text")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"channel": "C01ABC",
+			"ts":      "1709251200.000100",
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("SLACK_TOKEN", "xoxb-test")
+	t.Setenv("SLACK_API_URL", srv.URL+"/api/")
+
+	var cli cmd.CLI
+	var outBuf, errBuf bytes.Buffer
+
+	parser, err := kong.New(&cli, kong.Name("slack"), kong.Exit(func(int) {}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kctx, err := parser.Parse([]string{"message", "post", "C01ABC", "--stdin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli.SetOutput(&outBuf, &errBuf)
+	cli.SetInput(strings.NewReader("Hello from stdin\n"))
+
+	if err := kctx.Run(&cli); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotText != "Hello from stdin" {
+		t.Errorf("expected text='Hello from stdin', got %q", gotText)
+	}
+}
+
+func TestMessagePost_StdinTrimsCarriageReturn(t *testing.T) {
+	var gotText string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotText = r.FormValue("text")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"channel": "C01ABC",
+			"ts":      "1709251200.000100",
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("SLACK_TOKEN", "xoxb-test")
+	t.Setenv("SLACK_API_URL", srv.URL+"/api/")
+
+	var cli cmd.CLI
+	var outBuf, errBuf bytes.Buffer
+
+	parser, err := kong.New(&cli, kong.Name("slack"), kong.Exit(func(int) {}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kctx, err := parser.Parse([]string{"message", "post", "C01ABC", "--stdin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli.SetOutput(&outBuf, &errBuf)
+	cli.SetInput(strings.NewReader("Windows text\r\n"))
+
+	if err := kctx.Run(&cli); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotText != "Windows text" {
+		t.Errorf("expected text='Windows text', got %q", gotText)
 	}
 }

--- a/cmd/post_test.go
+++ b/cmd/post_test.go
@@ -1,0 +1,133 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestMessagePost_Text(t *testing.T) {
+	var gotText, gotChannel string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotText = r.FormValue("text")
+		gotChannel = r.FormValue("channel")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"channel": gotChannel,
+			"ts":      "1709251200.000100",
+		})
+	})
+
+	out, err := runWithMock(t, mux, "message", "post", "C01ABC", "--text", "Deploy complete")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotText != "Deploy complete" {
+		t.Errorf("expected text='Deploy complete', got %q", gotText)
+	}
+	if gotChannel != "C01ABC" {
+		t.Errorf("expected channel='C01ABC', got %q", gotChannel)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (result + meta), got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["channel"] != "C01ABC" {
+		t.Errorf("expected channel='C01ABC', got %q", item["channel"])
+	}
+	if item["ts"] != "1709251200.000100" {
+		t.Errorf("expected ts, got %q", item["ts"])
+	}
+	if _, ok := item["ts_iso"]; !ok {
+		t.Error("expected ts_iso field")
+	}
+}
+
+func TestMessagePost_Thread(t *testing.T) {
+	var gotThreadTS string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotThreadTS = r.FormValue("thread_ts")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"channel": "C01ABC",
+			"ts":      "1709251200.000200",
+		})
+	})
+
+	out, err := runWithMock(t, mux, "message", "post", "C01ABC", "--text", "reply", "--thread", "1709251200.000100")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotThreadTS != "1709251200.000100" {
+		t.Errorf("expected thread_ts='1709251200.000100', got %q", gotThreadTS)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+}
+
+func TestMessagePost_ChannelResolution(t *testing.T) {
+	var gotChannel string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"channels": []map[string]any{
+				{"id": "C01ABC", "name": "general", "is_member": true},
+			},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		})
+	})
+	mux.HandleFunc("/api/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotChannel = r.FormValue("channel")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"channel": gotChannel,
+			"ts":      "1709251200.000100",
+		})
+	})
+
+	_, err := runWithMock(t, mux, "message", "post", "#general", "--text", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotChannel != "C01ABC" {
+		t.Errorf("expected resolved channel C01ABC, got %q", gotChannel)
+	}
+}
+
+func TestMessagePost_MissingText(t *testing.T) {
+	mux := http.NewServeMux()
+	_, err := runWithMock(t, mux, "message", "post", "C01ABC")
+	if err == nil {
+		t.Fatal("expected error when no --text or --stdin")
+	}
+}
+
+func TestMessagePost_APIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "not_authed",
+		})
+	})
+
+	_, err := runWithMock(t, mux, "message", "post", "C01ABC", "--text", "hello")
+	if err == nil {
+		t.Fatal("expected error for not_authed")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,9 +18,10 @@ type CLI struct {
 	Quiet      bool   `short:"q" help:"Suppress stdout output (exit code and stderr only)."`
 	APIBaseURL string `hidden:"" env:"SLACK_API_URL" help:"Override Slack API base URL (for testing)."`
 
-	// stdout/stderr overrides for testing.
+	// stdout/stderr/stdin overrides for testing.
 	out io.Writer
 	err io.Writer
+	in  io.Reader
 
 	// Set by NewClient from resolved credentials.
 	authMethod string
@@ -57,6 +58,19 @@ func (c *CLI) ParsedFields() []string {
 func (c *CLI) SetOutput(out, errW io.Writer) {
 	c.out = out
 	c.err = errW
+}
+
+// SetInput overrides stdin for testing.
+func (c *CLI) SetInput(in io.Reader) {
+	c.in = in
+}
+
+// Stdin returns the stdin reader, defaulting to os.Stdin.
+func (c *CLI) Stdin() io.Reader {
+	if c.in != nil {
+		return c.in
+	}
+	return os.Stdin
 }
 
 // SetAuthMethod overrides the auth method for testing ClassifyError hints.


### PR DESCRIPTION
## Summary

- Add `slack message post <channel> --text <text>` via `chat.postMessage`
- Supports `--stdin` for piped input and `--thread` for reply threads
- Channel name resolution, timestamp ISO formatting

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] Tests for: text posting, thread replies, channel resolution, missing text error, API error

🤖 Generated with [Claude Code](https://claude.com/claude-code)