### PR TITLE
feat: add search files command

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -14,6 +14,7 @@ import (
 
 type SearchCmd struct {
 	Messages SearchMessagesCmd `cmd:"" help:"Search messages."`
+	Files    SearchFilesCmd    `cmd:"" help:"Search files."`
 }
 
 type SearchMessagesCmd struct {
@@ -106,6 +107,105 @@ func (c *SearchMessagesCmd) Run(cli *CLI) error {
 
 		page++
 	}
+}
+
+type SearchFilesCmd struct {
+	Query   string `arg:"" required:"" help:"Search query (supports Slack search modifiers)."`
+	Limit   int    `help:"Page size." default:"20"`
+	Cursor  string `help:"Continue from previous page."`
+	All     bool   `help:"Fetch all pages."`
+	Sort    string `help:"Sort order: timestamp, score." default:"timestamp" enum:"timestamp,score"`
+	SortDir string `help:"Sort direction: asc, desc." default:"desc" name:"sort-dir" enum:"asc,desc"`
+}
+
+func (c *SearchFilesCmd) Run(cli *CLI) error {
+	if c.All && c.Cursor != "" {
+		return &output.Error{Err: "invalid_input", Detail: "--all and --cursor are mutually exclusive", Code: output.ExitGeneral}
+	}
+
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	if client.User() == nil {
+		return &output.Error{
+			Err:    "missing_user_token",
+			Detail: "Search requires a user token",
+			Hint:   "Set SLACK_USER_TOKEN or re-run 'slack auth login'",
+			Code:   output.ExitAuth,
+		}
+	}
+
+	p := cli.NewPrinter()
+	ctx := context.Background()
+
+	limit := c.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		return &output.Error{Err: "invalid_input", Detail: "--limit must be between 1 and 100", Code: output.ExitGeneral}
+	}
+
+	page := 1
+	if c.Cursor != "" {
+		decoded, err := base64.StdEncoding.DecodeString(c.Cursor)
+		if err != nil {
+			return &output.Error{Err: "invalid_cursor", Detail: "Cannot decode cursor", Code: output.ExitGeneral}
+		}
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 || parts[0] != "page" {
+			return &output.Error{Err: "invalid_cursor", Detail: "Malformed cursor", Code: output.ExitGeneral}
+		}
+		page, err = strconv.Atoi(parts[1])
+		if err != nil || page < 1 {
+			return &output.Error{Err: "invalid_cursor", Detail: "Invalid page in cursor", Code: output.ExitGeneral}
+		}
+	}
+
+	for {
+		params := slack.SearchParameters{
+			Sort:          c.Sort,
+			SortDirection: c.SortDir,
+			Count:         limit,
+			Page:          page,
+		}
+
+		files, err := client.User().SearchFilesContext(ctx, c.Query, params)
+		if err != nil {
+			return cli.ClassifyError(err)
+		}
+
+		for _, f := range files.Matches {
+			if err := p.PrintItem(fileToMap(f)); err != nil {
+				return err
+			}
+		}
+
+		hasMore := files.Paging.Page < files.Paging.Pages
+		if !c.All || !hasMore {
+			nextCursor := ""
+			if hasMore {
+				nextCursor = base64.StdEncoding.EncodeToString(
+					[]byte(fmt.Sprintf("page:%d", files.Paging.Page+1)),
+				)
+			}
+			return p.PrintMeta(output.Meta{
+				HasMore:    hasMore,
+				NextCursor: nextCursor,
+			})
+		}
+
+		page++
+	}
+}
+
+func fileToMap(f slack.File) map[string]any {
+	data, _ := json.Marshal(f)
+	var m map[string]any
+	_ = json.Unmarshal(data, &m)
+	return m
 }
 
 func searchMessageToMap(msg slack.SearchMessage) map[string]any {

--- a/cmd/search_files_test.go
+++ b/cmd/search_files_test.go
@@ -1,0 +1,116 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func searchFilesResponse(matches []map[string]any, page, pageCount, total int) map[string]any {
+	return map[string]any{
+		"ok": true,
+		"files": map[string]any{
+			"matches": matches,
+			"paging": map[string]any{
+				"count": len(matches),
+				"total": total,
+				"page":  page,
+				"pages": pageCount,
+			},
+			"total": total,
+		},
+	}
+}
+
+func fileMatch(id, name, title, filetype, permalink string) map[string]any {
+	return map[string]any{
+		"id":        id,
+		"name":      name,
+		"title":     title,
+		"filetype":  filetype,
+		"permalink": permalink,
+	}
+}
+
+func TestSearchFiles_Basic(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search.files", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if q := r.Form.Get("query"); q != "quarterly report" {
+			t.Errorf("expected query 'quarterly report', got %q", q)
+		}
+		_ = json.NewEncoder(w).Encode(searchFilesResponse(
+			[]map[string]any{
+				fileMatch("F01ABC", "Q1-report.pdf", "Q1 Quarterly Report", "pdf", "https://acme.slack.com/files/U01/F01ABC/q1.pdf"),
+				fileMatch("F02DEF", "Q4-report.xlsx", "Q4 Quarterly Report", "xlsx", "https://acme.slack.com/files/U02/F02DEF/q4.xlsx"),
+			},
+			1, 1, 2,
+		))
+	})
+
+	t.Setenv("SLACK_USER_TOKEN", "xoxp-test")
+	out, err := runWithMock(t, mux, "search", "files", "quarterly report")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (2 files + meta), got %d:\n%s", len(lines), out)
+	}
+
+	f := parseJSON(t, lines[0])
+	if f["id"] != "F01ABC" {
+		t.Errorf("expected id='F01ABC', got %q", f["id"])
+	}
+	if f["name"] != "Q1-report.pdf" {
+		t.Errorf("expected name='Q1-report.pdf', got %q", f["name"])
+	}
+}
+
+func TestSearchFiles_Pagination(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search.files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(searchFilesResponse(
+			[]map[string]any{
+				fileMatch("F01ABC", "file.pdf", "File", "pdf", "https://acme.slack.com/files/F01"),
+			},
+			1, 3, 5,
+		))
+	})
+
+	t.Setenv("SLACK_USER_TOKEN", "xoxp-test")
+	out, err := runWithMock(t, mux, "search", "files", "test", "--limit", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	meta := parseJSON(t, lines[len(lines)-1])
+	m := meta["_meta"].(map[string]any)
+	if m["has_more"] != true {
+		t.Error("expected has_more=true")
+	}
+	if m["next_cursor"] == nil || m["next_cursor"] == "" {
+		t.Error("expected non-empty next_cursor")
+	}
+}
+
+func TestSearchFiles_MissingUserToken(t *testing.T) {
+	mux := http.NewServeMux()
+	t.Setenv("SLACK_USER_TOKEN", "")
+
+	_, err := runWithMock(t, mux, "search", "files", "test query")
+	if err == nil {
+		t.Fatal("expected error for missing user token")
+	}
+}
+
+func TestSearchFiles_LimitExceeded(t *testing.T) {
+	mux := http.NewServeMux()
+	t.Setenv("SLACK_USER_TOKEN", "xoxp-test")
+	_, err := runWithMock(t, mux, "search", "files", "test", "--limit", "150")
+	if err == nil {
+		t.Fatal("expected error for limit > 100")
+	}
+}

--- a/cmd/search_files_test.go
+++ b/cmd/search_files_test.go
@@ -2,8 +2,11 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
+
+	"github.com/tammersaleh/slack-cli/internal/output"
 )
 
 func searchFilesResponse(matches []map[string]any, page, pageCount, total int) map[string]any {
@@ -69,30 +72,97 @@ func TestSearchFiles_Basic(t *testing.T) {
 }
 
 func TestSearchFiles_Pagination(t *testing.T) {
+	callCount := 0
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/search.files", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(searchFilesResponse(
-			[]map[string]any{
-				fileMatch("F01ABC", "file.pdf", "File", "pdf", "https://acme.slack.com/files/F01"),
-			},
-			1, 3, 5,
-		))
+		callCount++
+		_ = r.ParseForm()
+		page := r.Form.Get("page")
+
+		if page == "" || page == "1" {
+			_ = json.NewEncoder(w).Encode(searchFilesResponse(
+				[]map[string]any{fileMatch("F01", "page1.pdf", "Page 1", "pdf", "https://acme.slack.com/files/F01")},
+				1, 2, 2,
+			))
+		} else if page == "2" {
+			_ = json.NewEncoder(w).Encode(searchFilesResponse(
+				[]map[string]any{fileMatch("F02", "page2.pdf", "Page 2", "pdf", "https://acme.slack.com/files/F02")},
+				2, 2, 2,
+			))
+		} else {
+			t.Fatalf("unexpected page %q", page)
+		}
 	})
 
 	t.Setenv("SLACK_USER_TOKEN", "xoxp-test")
-	out, err := runWithMock(t, mux, "search", "files", "test", "--limit", "2")
+
+	// First page should show has_more=true with a cursor.
+	out, err := runWithMock(t, mux, "search", "files", "test", "--limit", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := nonEmptyLines(out)
+	meta := parseJSON(t, lines[len(lines)-1])
+	m := meta["_meta"].(map[string]any)
+	if m["has_more"] != true {
+		t.Error("expected has_more=true on first page")
+	}
+	cursor := m["next_cursor"].(string)
+	if cursor == "" {
+		t.Fatal("expected non-empty cursor")
+	}
+
+	// Second page using the cursor.
+	out2, err := runWithMock(t, mux, "search", "files", "test", "--cursor", cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines2 := nonEmptyLines(out2)
+	meta2 := parseJSON(t, lines2[len(lines2)-1])
+	m2 := meta2["_meta"].(map[string]any)
+	if m2["has_more"] != false {
+		t.Error("expected has_more=false on last page")
+	}
+
+	f := parseJSON(t, lines2[0])
+	if f["id"] != "F02" {
+		t.Errorf("expected page 2 file F02, got %q", f["id"])
+	}
+}
+
+func TestSearchFiles_All(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search.files", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		page := r.Form.Get("page")
+		if page == "" || page == "1" {
+			_ = json.NewEncoder(w).Encode(searchFilesResponse(
+				[]map[string]any{fileMatch("F01", "a.pdf", "A", "pdf", "")},
+				1, 2, 2,
+			))
+		} else {
+			_ = json.NewEncoder(w).Encode(searchFilesResponse(
+				[]map[string]any{fileMatch("F02", "b.pdf", "B", "pdf", "")},
+				2, 2, 2,
+			))
+		}
+	})
+
+	t.Setenv("SLACK_USER_TOKEN", "xoxp-test")
+	out, err := runWithMock(t, mux, "search", "files", "test", "--all")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	lines := nonEmptyLines(out)
-	meta := parseJSON(t, lines[len(lines)-1])
-	m := meta["_meta"].(map[string]any)
-	if m["has_more"] != true {
-		t.Error("expected has_more=true")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (2 files + meta), got %d:\n%s", len(lines), out)
 	}
-	if m["next_cursor"] == nil || m["next_cursor"] == "" {
-		t.Error("expected non-empty next_cursor")
+
+	meta := parseJSON(t, lines[2])
+	m := meta["_meta"].(map[string]any)
+	if m["has_more"] != false {
+		t.Error("expected has_more=false after --all")
 	}
 }
 
@@ -104,6 +174,17 @@ func TestSearchFiles_MissingUserToken(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing user token")
 	}
+
+	var oErr *output.Error
+	if !errors.As(err, &oErr) {
+		t.Fatalf("expected *output.Error, got %T", err)
+	}
+	if oErr.Err != "missing_user_token" {
+		t.Errorf("expected error='missing_user_token', got %q", oErr.Err)
+	}
+	if oErr.Code != output.ExitAuth {
+		t.Errorf("expected exit code %d, got %d", output.ExitAuth, oErr.Code)
+	}
 }
 
 func TestSearchFiles_LimitExceeded(t *testing.T) {
@@ -112,5 +193,46 @@ func TestSearchFiles_LimitExceeded(t *testing.T) {
 	_, err := runWithMock(t, mux, "search", "files", "test", "--limit", "150")
 	if err == nil {
 		t.Fatal("expected error for limit > 100")
+	}
+
+	var oErr *output.Error
+	if !errors.As(err, &oErr) {
+		t.Fatalf("expected *output.Error, got %T", err)
+	}
+	if oErr.Err != "invalid_input" {
+		t.Errorf("expected error='invalid_input', got %q", oErr.Err)
+	}
+}
+
+func TestSearchFiles_AllAndCursorMutuallyExclusive(t *testing.T) {
+	mux := http.NewServeMux()
+	t.Setenv("SLACK_USER_TOKEN", "xoxp-test")
+	_, err := runWithMock(t, mux, "search", "files", "test", "--all", "--cursor", "abc")
+	if err == nil {
+		t.Fatal("expected error for --all and --cursor together")
+	}
+}
+
+func TestSearchFiles_NotAuthed(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search.files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "not_authed",
+		})
+	})
+
+	t.Setenv("SLACK_USER_TOKEN", "xoxp-expired")
+	_, err := runWithMock(t, mux, "search", "files", "test query")
+	if err == nil {
+		t.Fatal("expected error for not_authed")
+	}
+
+	var oErr *output.Error
+	if !errors.As(err, &oErr) {
+		t.Fatalf("expected *output.Error, got %T", err)
+	}
+	if oErr.Code != output.ExitAuth {
+		t.Errorf("expected exit code %d, got %d", output.ExitAuth, oErr.Code)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `slack search files <query>` via `search.files` API
- Same flags as search messages: --limit, --cursor, --all, --sort, --sort-dir
- Requires user token (same as search messages)

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] Tests for: basic search, pagination, missing user token, limit validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)