### PR TITLE
feat: add file list, info, and download commands

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -1,0 +1,198 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/slack-go/slack"
+	"github.com/tammersaleh/slack-cli/internal/output"
+)
+
+type FileCmd struct {
+	List     FileListCmd     `cmd:"" help:"List files."`
+	Info     FileInfoCmd     `cmd:"" help:"Show file details."`
+	Download FileDownloadCmd `cmd:"" help:"Download a file."`
+}
+
+type FileListCmd struct {
+	Limit   int    `help:"Page size." default:"20"`
+	Cursor  string `help:"Continue from previous page."`
+	All     bool   `help:"Fetch all pages."`
+	Channel string `help:"Filter by channel ID or name."`
+	User    string `help:"Filter by user ID."`
+	Types   string `help:"Comma-separated file types (e.g. images,pdfs)."`
+}
+
+func (c *FileListCmd) Run(cli *CLI) error {
+	if c.All && c.Cursor != "" {
+		return &output.Error{Err: "invalid_input", Detail: "--all and --cursor are mutually exclusive", Code: output.ExitGeneral}
+	}
+
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	p := cli.NewPrinter()
+	ctx := context.Background()
+
+	limit := c.Limit
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+
+	channelID := c.Channel
+	if channelID != "" {
+		r := cli.NewResolver(client)
+		resolved, err := r.ResolveChannel(ctx, channelID)
+		if err == nil {
+			channelID = resolved
+		}
+	}
+
+	page := 1
+
+	for {
+		params := slack.GetFilesParameters{
+			Channel: channelID,
+			User:    c.User,
+			Types:   c.Types,
+			Count:   limit,
+			Page:    page,
+		}
+
+		files, paging, err := client.Bot().GetFilesContext(ctx, params)
+		if err != nil {
+			return cli.ClassifyError(err)
+		}
+
+		for _, f := range files {
+			if err := p.PrintItem(fileToMap(f)); err != nil {
+				return err
+			}
+		}
+
+		hasMore := paging != nil && paging.Page < paging.Pages
+		if !c.All || !hasMore {
+			nextCursor := ""
+			if hasMore {
+				nextCursor = base64.StdEncoding.EncodeToString(
+					[]byte(fmt.Sprintf("page:%d", paging.Page+1)),
+				)
+			}
+			return p.PrintMeta(output.Meta{
+				HasMore:    hasMore,
+				NextCursor: nextCursor,
+			})
+		}
+
+		page++
+	}
+}
+
+type FileInfoCmd struct {
+	Files []string `arg:"" required:"" help:"File IDs."`
+}
+
+func (c *FileInfoCmd) Run(cli *CLI) error {
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	p := cli.NewPrinter()
+	ctx := context.Background()
+	errorCount := 0
+
+	for _, id := range c.Files {
+		file, _, _, err := client.Bot().GetFileInfoContext(ctx, id, 0, 0)
+		if err != nil {
+			errorCount++
+			if err := p.PrintItem(map[string]any{
+				"input":  id,
+				"error":  "file_not_found",
+				"detail": "No file matching '" + id + "'",
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+
+		m := fileToMap(*file)
+		m["input"] = id
+		if err := p.PrintItem(m); err != nil {
+			return err
+		}
+	}
+
+	meta := output.Meta{ErrorCount: errorCount}
+	if err := p.PrintMeta(meta); err != nil {
+		return err
+	}
+	if errorCount > 0 {
+		return &output.ExitError{Code: output.ExitGeneral}
+	}
+	return nil
+}
+
+type FileDownloadCmd struct {
+	File   string `arg:"" required:"" help:"File ID."`
+	Output string `help:"Output path (default: original filename, '-' for stdout)." short:"o"`
+}
+
+func (c *FileDownloadCmd) Run(cli *CLI) error {
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	p := cli.NewPrinter()
+	ctx := context.Background()
+
+	file, _, _, err := client.Bot().GetFileInfoContext(ctx, c.File, 0, 0)
+	if err != nil {
+		return cli.ClassifyError(err)
+	}
+
+	if file.URLPrivateDownload == "" {
+		return &output.Error{Err: "no_download_url", Detail: "File has no download URL", Code: output.ExitGeneral}
+	}
+
+	if c.Output == "-" {
+		out := io.Writer(os.Stdout)
+		if cli.out != nil {
+			out = cli.out
+		}
+		return client.Bot().GetFileContext(ctx, file.URLPrivateDownload, out)
+	}
+
+	outPath := c.Output
+	if outPath == "" {
+		outPath = filepath.Base(file.Name)
+	}
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		return &output.Error{Err: "file_error", Detail: err.Error(), Code: output.ExitGeneral}
+	}
+	defer f.Close()
+
+	if err := client.Bot().GetFileContext(ctx, file.URLPrivateDownload, f); err != nil {
+		return cli.ClassifyError(err)
+	}
+
+	if err := p.PrintItem(map[string]any{
+		"input": c.File,
+		"id":    file.ID,
+		"name":  file.Name,
+		"size":  file.Size,
+		"path":  outPath,
+	}); err != nil {
+		return err
+	}
+	return p.PrintMeta(output.Meta{})
+}

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -111,11 +111,15 @@ func (c *FileInfoCmd) Run(cli *CLI) error {
 	for _, id := range c.Files {
 		file, _, _, err := client.Bot().GetFileInfoContext(ctx, id, 0, 0)
 		if err != nil {
+			oErr := cli.ClassifyError(err)
+			if oErr.Code != output.ExitGeneral {
+				return oErr
+			}
 			errorCount++
 			if err := p.PrintItem(map[string]any{
 				"input":  id,
-				"error":  "file_not_found",
-				"detail": "No file matching '" + id + "'",
+				"error":  oErr.Err,
+				"detail": oErr.Detail,
 			}); err != nil {
 				return err
 			}
@@ -167,23 +171,31 @@ func (c *FileDownloadCmd) Run(cli *CLI) error {
 		if cli.out != nil {
 			out = cli.out
 		}
-		return client.Bot().GetFileContext(ctx, file.URLPrivateDownload, out)
+		if err := client.Bot().GetFileContext(ctx, file.URLPrivateDownload, out); err != nil {
+			return cli.ClassifyError(err)
+		}
+		return nil
 	}
 
 	outPath := c.Output
 	if outPath == "" {
 		outPath = filepath.Base(file.Name)
 	}
+	if outPath == "" || outPath == "." {
+		outPath = file.ID
+	}
 
 	f, err := os.Create(outPath)
 	if err != nil {
 		return &output.Error{Err: "file_error", Detail: err.Error(), Code: output.ExitGeneral}
 	}
-	defer f.Close()
 
 	if err := client.Bot().GetFileContext(ctx, file.URLPrivateDownload, f); err != nil {
+		f.Close()
+		_ = os.Remove(outPath)
 		return cli.ClassifyError(err)
 	}
+	f.Close()
 
 	if err := p.PrintItem(map[string]any{
 		"input": c.File,

--- a/cmd/file_test.go
+++ b/cmd/file_test.go
@@ -1,0 +1,135 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestFileList_Basic(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/files.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"files": []map[string]any{
+				{"id": "F01", "name": "report.pdf", "filetype": "pdf", "size": 1024},
+				{"id": "F02", "name": "image.png", "filetype": "png", "size": 2048},
+			},
+			"paging": map[string]any{"count": 2, "total": 2, "page": 1, "pages": 1},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "file", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (2 files + meta), got %d:\n%s", len(lines), out)
+	}
+
+	f := parseJSON(t, lines[0])
+	if f["id"] != "F01" {
+		t.Errorf("expected id='F01', got %q", f["id"])
+	}
+	if f["name"] != "report.pdf" {
+		t.Errorf("expected name='report.pdf', got %q", f["name"])
+	}
+}
+
+func TestFileList_Pagination(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/files.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"files": []map[string]any{
+				{"id": "F01", "name": "file.pdf"},
+			},
+			"paging": map[string]any{"count": 1, "total": 5, "page": 1, "pages": 3},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "file", "list", "--limit", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	meta := parseJSON(t, lines[len(lines)-1])
+	m := meta["_meta"].(map[string]any)
+	if m["has_more"] != true {
+		t.Error("expected has_more=true")
+	}
+	if m["next_cursor"] == nil || m["next_cursor"] == "" {
+		t.Error("expected non-empty next_cursor")
+	}
+}
+
+func TestFileInfo_Basic(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/files.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		fid := r.FormValue("file")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"file": map[string]any{
+				"id":       fid,
+				"name":     "report.pdf",
+				"filetype": "pdf",
+				"size":     1048576,
+			},
+			"comments": []any{},
+			"paging":   map[string]any{"count": 0, "total": 0, "page": 1, "pages": 1},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "file", "info", "F01ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (1 file + meta), got %d:\n%s", len(lines), out)
+	}
+
+	f := parseJSON(t, lines[0])
+	if f["id"] != "F01ABC" {
+		t.Errorf("expected id='F01ABC', got %q", f["id"])
+	}
+	if f["input"] != "F01ABC" {
+		t.Errorf("expected input='F01ABC', got %q", f["input"])
+	}
+	if f["name"] != "report.pdf" {
+		t.Errorf("expected name='report.pdf', got %q", f["name"])
+	}
+}
+
+func TestFileInfo_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/files.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "file_not_found",
+		})
+	})
+
+	out, err := runWithMock(t, mux, "file", "info", "F99MISSING")
+	if err == nil {
+		t.Fatal("expected error for not found file")
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (error + meta), got %d:\n%s", len(lines), out)
+	}
+
+	errItem := parseJSON(t, lines[0])
+	if errItem["error"] != "file_not_found" {
+		t.Errorf("expected error='file_not_found', got %q", errItem["error"])
+	}
+	if errItem["input"] != "F99MISSING" {
+		t.Errorf("expected input='F99MISSING', got %q", errItem["input"])
+	}
+}

--- a/cmd/file_test.go
+++ b/cmd/file_test.go
@@ -1,9 +1,16 @@
 package cmd_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/tammersaleh/slack-cli/cmd"
 )
 
 func TestFileList_Basic(t *testing.T) {
@@ -131,5 +138,128 @@ func TestFileInfo_NotFound(t *testing.T) {
 	}
 	if errItem["input"] != "F99MISSING" {
 		t.Errorf("expected input='F99MISSING', got %q", errItem["input"])
+	}
+}
+
+func fileDownloadMux(t *testing.T, fileContent string) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/files.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"file": map[string]any{
+				"id":                   "F01ABC",
+				"name":                 "report.pdf",
+				"size":                 len(fileContent),
+				"url_private_download": "http://" + r.Host + "/download/report.pdf",
+			},
+			"comments": []any{},
+			"paging":   map[string]any{"count": 0, "total": 0, "page": 1, "pages": 1},
+		})
+	})
+	mux.HandleFunc("/download/report.pdf", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write([]byte(fileContent))
+	})
+	return mux
+}
+
+func TestFileDownload_ToDisk(t *testing.T) {
+	content := "fake-pdf-content"
+	mux := fileDownloadMux(t, content)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Setenv("SLACK_TOKEN", "xoxb-test")
+	t.Setenv("SLACK_API_URL", srv.URL+"/api/")
+
+	outDir := t.TempDir()
+	outPath := filepath.Join(outDir, "downloaded.pdf")
+
+	var cli cmd.CLI
+	var outBuf, errBuf bytes.Buffer
+
+	parser, err := kong.New(&cli, kong.Name("slack"), kong.Exit(func(int) {}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kctx, err := parser.Parse([]string{"file", "download", "F01ABC", "-o", outPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli.SetOutput(&outBuf, &errBuf)
+	if err := kctx.Run(&cli); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("file not written: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf("expected content %q, got %q", content, string(data))
+	}
+
+	lines := nonEmptyLines(outBuf.String())
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (result + meta), got %d:\n%s", len(lines), outBuf.String())
+	}
+	item := parseJSON(t, lines[0])
+	if item["path"] != outPath {
+		t.Errorf("expected path=%q, got %q", outPath, item["path"])
+	}
+}
+
+func TestFileDownload_ToStdout(t *testing.T) {
+	content := "stdout-content"
+	mux := fileDownloadMux(t, content)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Setenv("SLACK_TOKEN", "xoxb-test")
+	t.Setenv("SLACK_API_URL", srv.URL+"/api/")
+
+	var cli cmd.CLI
+	var outBuf, errBuf bytes.Buffer
+
+	parser, err := kong.New(&cli, kong.Name("slack"), kong.Exit(func(int) {}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kctx, err := parser.Parse([]string{"file", "download", "F01ABC", "-o", "-"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli.SetOutput(&outBuf, &errBuf)
+	if err := kctx.Run(&cli); err != nil {
+		t.Fatal(err)
+	}
+
+	if outBuf.String() != content {
+		t.Errorf("expected stdout content %q, got %q", content, outBuf.String())
+	}
+}
+
+func TestFileDownload_NoDownloadURL(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/files.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"file": map[string]any{
+				"id":   "F01ABC",
+				"name": "snippet.txt",
+			},
+			"comments": []any{},
+			"paging":   map[string]any{"count": 0, "total": 0, "page": 1, "pages": 1},
+		})
+	})
+
+	_, err := runWithMock(t, mux, "file", "download", "F01ABC")
+	if err == nil {
+		t.Fatal("expected error for no download URL")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ type CLI struct {
 
 	Auth     AuthCmd     `cmd:"" help:"Manage authentication."`
 	Channel  ChannelCmd  `cmd:"" help:"Read channel information."`
+	File     FileCmd     `cmd:"" help:"File operations."`
 	Message  MessageCmd  `cmd:"" help:"Read messages."`
 	Saved    SavedCmd    `cmd:"" help:"Saved-for-later items (requires session token)."`
 	Search   SearchCmd   `cmd:"" help:"Search messages and files."`


### PR DESCRIPTION
## Summary

- Add `slack file list` with pagination and channel/user/type filters
- Add `slack file info <id>...` with per-item error handling
- Add `slack file download <id>` with `--output` flag (file or stdout)

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] Tests for: file list basic + pagination, file info basic + not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)