### PR TITLE
feat: add pin list and bookmark list commands

### DIFF
--- a/cmd/bookmark.go
+++ b/cmd/bookmark.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/slack-go/slack"
+	"github.com/tammersaleh/slack-cli/internal/output"
+)
+
+type BookmarkCmd struct {
+	List BookmarkListCmd `cmd:"" help:"List bookmarks in a channel."`
+}
+
+type BookmarkListCmd struct {
+	Channel string `arg:"" required:"" help:"Channel ID or name."`
+}
+
+func (c *BookmarkListCmd) Run(cli *CLI) error {
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	p := cli.NewPrinter()
+	r := cli.NewResolver(client)
+	ctx := context.Background()
+
+	channelID, err := r.ResolveChannel(ctx, c.Channel)
+	if err != nil {
+		return &output.Error{Err: "channel_not_found", Detail: "No channel matching '" + c.Channel + "'", Code: output.ExitGeneral}
+	}
+
+	bookmarks, err := client.Bot().ListBookmarksContext(ctx, channelID)
+	if err != nil {
+		return cli.ClassifyError(err)
+	}
+
+	for _, bm := range bookmarks {
+		if err := p.PrintItem(bookmarkToMap(bm)); err != nil {
+			return err
+		}
+	}
+
+	return p.PrintMeta(output.Meta{})
+}
+
+func bookmarkToMap(bm slack.Bookmark) map[string]any {
+	data, _ := json.Marshal(bm)
+	var m map[string]any
+	_ = json.Unmarshal(data, &m)
+	return m
+}

--- a/cmd/bookmark_test.go
+++ b/cmd/bookmark_test.go
@@ -1,0 +1,50 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestBookmarkList(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/bookmarks.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if ch := r.FormValue("channel_id"); ch != "C01ABC" {
+			t.Errorf("expected channel_id='C01ABC', got %q", ch)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"bookmarks": []map[string]any{
+				{
+					"id":         "Bk01",
+					"channel_id": "C01ABC",
+					"title":      "Team Wiki",
+					"link":       "https://wiki.example.com",
+					"type":       "link",
+				},
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "bookmark", "list", "C01ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (1 bookmark + meta), got %d:\n%s", len(lines), out)
+	}
+
+	bm := parseJSON(t, lines[0])
+	if bm["id"] != "Bk01" {
+		t.Errorf("expected id='Bk01', got %q", bm["id"])
+	}
+	if bm["title"] != "Team Wiki" {
+		t.Errorf("expected title='Team Wiki', got %q", bm["title"])
+	}
+	if bm["link"] != "https://wiki.example.com" {
+		t.Errorf("expected link, got %q", bm["link"])
+	}
+}

--- a/cmd/bookmark_test.go
+++ b/cmd/bookmark_test.go
@@ -47,4 +47,43 @@ func TestBookmarkList(t *testing.T) {
 	if bm["link"] != "https://wiki.example.com" {
 		t.Errorf("expected link, got %q", bm["link"])
 	}
+
+	meta := parseJSON(t, lines[1])
+	m := meta["_meta"].(map[string]any)
+	if m["has_more"] != false {
+		t.Error("expected has_more=false")
+	}
+}
+
+func TestBookmarkList_ChannelResolution(t *testing.T) {
+	bookmarksCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"channels": []map[string]any{
+				{"id": "C01ABC", "name": "general", "is_member": true},
+			},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		})
+	})
+	mux.HandleFunc("/api/bookmarks.list", func(w http.ResponseWriter, r *http.Request) {
+		bookmarksCalled = true
+		_ = r.ParseForm()
+		if ch := r.FormValue("channel_id"); ch != "C01ABC" {
+			t.Errorf("expected resolved channel_id C01ABC, got %q", ch)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":        true,
+			"bookmarks": []map[string]any{},
+		})
+	})
+
+	_, err := runWithMock(t, mux, "bookmark", "list", "#general")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bookmarksCalled {
+		t.Error("expected bookmarks.list to be called")
+	}
 }

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/slack-go/slack"
+	"github.com/tammersaleh/slack-cli/internal/output"
+)
+
+type PinCmd struct {
+	List PinListCmd `cmd:"" help:"List pinned items in a channel."`
+}
+
+type PinListCmd struct {
+	Channel string `arg:"" required:"" help:"Channel ID or name."`
+}
+
+func (c *PinListCmd) Run(cli *CLI) error {
+	client, err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+
+	p := cli.NewPrinter()
+	r := cli.NewResolver(client)
+	ctx := context.Background()
+
+	channelID, err := r.ResolveChannel(ctx, c.Channel)
+	if err != nil {
+		return &output.Error{Err: "channel_not_found", Detail: "No channel matching '" + c.Channel + "'", Code: output.ExitGeneral}
+	}
+
+	items, _, err := client.Bot().ListPinsContext(ctx, channelID)
+	if err != nil {
+		return cli.ClassifyError(err)
+	}
+
+	for _, item := range items {
+		if err := p.PrintItem(pinItemToMap(item)); err != nil {
+			return err
+		}
+	}
+
+	return p.PrintMeta(output.Meta{})
+}
+
+func pinItemToMap(item slack.Item) map[string]any {
+	data, _ := json.Marshal(item)
+	var m map[string]any
+	_ = json.Unmarshal(data, &m)
+	return m
+}

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -1,0 +1,73 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestPinList(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/pins.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if ch := r.FormValue("channel"); ch != "C01ABC" {
+			t.Errorf("expected channel='C01ABC', got %q", ch)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"items": []map[string]any{
+				{
+					"type":    "message",
+					"channel": "C01ABC",
+					"message": map[string]any{"text": "pinned msg", "ts": "1709251200.000100", "user": "U01"},
+				},
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "pin", "list", "C01ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (1 pin + meta), got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["type"] != "message" {
+		t.Errorf("expected type='message', got %q", item["type"])
+	}
+	if item["channel"] != "C01ABC" {
+		t.Errorf("expected channel='C01ABC', got %q", item["channel"])
+	}
+}
+
+func TestPinList_ChannelResolution(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"channels": []map[string]any{
+				{"id": "C01ABC", "name": "general", "is_member": true},
+			},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		})
+	})
+	mux.HandleFunc("/api/pins.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if ch := r.FormValue("channel"); ch != "C01ABC" {
+			t.Errorf("expected resolved channel C01ABC, got %q", ch)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    true,
+			"items": []map[string]any{},
+		})
+	})
+
+	_, err := runWithMock(t, mux, "pin", "list", "#general")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -42,9 +42,16 @@ func TestPinList(t *testing.T) {
 	if item["channel"] != "C01ABC" {
 		t.Errorf("expected channel='C01ABC', got %q", item["channel"])
 	}
+
+	meta := parseJSON(t, lines[1])
+	m := meta["_meta"].(map[string]any)
+	if m["has_more"] != false {
+		t.Error("expected has_more=false")
+	}
 }
 
 func TestPinList_ChannelResolution(t *testing.T) {
+	pinsCalled := false
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/conversations.list", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -56,6 +63,7 @@ func TestPinList_ChannelResolution(t *testing.T) {
 		})
 	})
 	mux.HandleFunc("/api/pins.list", func(w http.ResponseWriter, r *http.Request) {
+		pinsCalled = true
 		_ = r.ParseForm()
 		if ch := r.FormValue("channel"); ch != "C01ABC" {
 			t.Errorf("expected resolved channel C01ABC, got %q", ch)
@@ -66,8 +74,16 @@ func TestPinList_ChannelResolution(t *testing.T) {
 		})
 	})
 
-	_, err := runWithMock(t, mux, "pin", "list", "#general")
+	out, err := runWithMock(t, mux, "pin", "list", "#general")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !pinsCalled {
+		t.Error("expected pins.list to be called")
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line (meta only), got %d:\n%s", len(lines), out)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,9 +28,11 @@ type CLI struct {
 	teamID     string
 
 	Auth     AuthCmd     `cmd:"" help:"Manage authentication."`
+	Bookmark BookmarkCmd `cmd:"" help:"Channel bookmarks."`
 	Channel  ChannelCmd  `cmd:"" help:"Read channel information."`
 	File     FileCmd     `cmd:"" help:"File operations."`
 	Message  MessageCmd  `cmd:"" help:"Read messages."`
+	Pin      PinCmd      `cmd:"" help:"Pinned items."`
 	Saved    SavedCmd    `cmd:"" help:"Saved-for-later items (requires session token)."`
 	Search   SearchCmd   `cmd:"" help:"Search messages and files."`
 	Section  SectionCmd  `cmd:"" help:"Manage sidebar sections (requires session token)."`


### PR DESCRIPTION
## Summary

- Add `slack pin list <channel>` via `pins.list`
- Add `slack bookmark list <channel>` via `bookmarks.list`
- Both support channel name resolution

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] Tests for: pin list with assertions, channel resolution, bookmark list with assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)