### PR TITLE
feat: add display name resolution to ResolveUser

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -110,17 +110,13 @@ Already spec'd in SPEC.md. Lower priority than message search.
 
 Branch: `feat/search-files`
 
-### Remaining Phase 2 items from SPEC.md
+### Remaining
 
-These are spec'd but lower priority for the MCP replacement goal:
-- `file list/info/download`
-- `pin list`
-- `bookmark list`
-- `status get`, `presence get`, `dnd info`
-- `user lookup`
-- `usergroup list/members`
-- `emoji list`
-- `workspace info`
+- Display name resolution (`@name`) in `ResolveUser` - add name
+  index to user cache so all user-accepting commands support `@name`
+  input. No separate `user lookup` command needed.
+- `channel mark` (Phase 3)
+- `auth switch` (Phase 3)
 
 ## Done
 

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -37,6 +37,7 @@ type Resolver struct {
 
 	users        map[string]slack.User // ID -> User
 	usersByEmail map[string]string     // email -> ID
+	usersByName  map[string]string     // lowercase display name -> ID
 	usersAt      time.Time
 }
 

--- a/internal/resolve/user.go
+++ b/internal/resolve/user.go
@@ -48,7 +48,21 @@ func (r *Resolver) ResolveUser(ctx context.Context, input string) (string, error
 		return user.ID, nil
 	}
 
-	return "", fmt.Errorf("cannot resolve user %q: expected a user ID (U...) or email address", input)
+	// Try display name / username lookup from cache.
+	name := input
+	if len(name) > 0 && name[0] == '@' {
+		name = name[1:]
+	}
+	if err := r.ensureUserCache(ctx); err == nil {
+		r.mu.RLock()
+		id, ok := r.usersByName[strings.ToLower(name)]
+		r.mu.RUnlock()
+		if ok {
+			return id, nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot resolve user %q: no match by ID, email, or name", input)
 }
 
 // LookupUser returns the full cached profile for a user ID. It populates
@@ -114,15 +128,36 @@ func (r *Resolver) bulkLoadUsers(ctx context.Context) error {
 	return nil
 }
 
-// setUserMaps populates the in-memory user and email index maps.
+// setUserMaps populates the in-memory user, email, and name index maps.
 // Must be called with r.mu held.
 func (r *Resolver) setUserMaps(users map[string]slack.User) {
 	r.users = users
 	r.usersAt = time.Now()
 	r.usersByEmail = make(map[string]string, len(users))
+	r.usersByName = make(map[string]string, len(users))
 	for id, u := range users {
 		if u.Profile.Email != "" {
 			r.usersByEmail[strings.ToLower(u.Profile.Email)] = id
+		}
+		// Index by username (first match wins on collision).
+		if u.Name != "" {
+			key := strings.ToLower(u.Name)
+			if _, exists := r.usersByName[key]; !exists {
+				r.usersByName[key] = id
+			}
+		}
+		// Also index by display name and real name.
+		if u.Profile.DisplayName != "" {
+			key := strings.ToLower(u.Profile.DisplayName)
+			if _, exists := r.usersByName[key]; !exists {
+				r.usersByName[key] = id
+			}
+		}
+		if u.RealName != "" {
+			key := strings.ToLower(u.RealName)
+			if _, exists := r.usersByName[key]; !exists {
+				r.usersByName[key] = id
+			}
 		}
 	}
 }

--- a/internal/resolve/user_cache_test.go
+++ b/internal/resolve/user_cache_test.go
@@ -290,3 +290,46 @@ func TestResolveUser_EmailFromFileCacheIndex(t *testing.T) {
 		t.Errorf("got %q, want %q", id, "U002")
 	}
 }
+
+func TestResolveUser_DisplayName(t *testing.T) {
+	calls := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		usersListHandler(t, testUsers())(w, r)
+	}))
+
+	r := NewResolver(client, "T123", t.TempDir())
+	id, err := r.ResolveUser(context.Background(), "@alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "U001" {
+		t.Errorf("got %q, want %q", id, "U001")
+	}
+	if calls != 1 {
+		t.Errorf("got %d API calls, want 1 (users.list only)", calls)
+	}
+}
+
+func TestResolveUser_DisplayNameCaseInsensitive(t *testing.T) {
+	client := newTestClient(t, usersListHandler(t, testUsers()))
+	r := NewResolver(client, "T123", t.TempDir())
+
+	id, err := r.ResolveUser(context.Background(), "@Alice Smith")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "U001" {
+		t.Errorf("got %q, want %q", id, "U001")
+	}
+}
+
+func TestResolveUser_DisplayNameNotFound(t *testing.T) {
+	client := newTestClient(t, usersListHandler(t, testUsers()))
+	r := NewResolver(client, "T123", t.TempDir())
+
+	_, err := r.ResolveUser(context.Background(), "@nonexistent")
+	if err == nil {
+		t.Error("expected error for unknown display name")
+	}
+}


### PR DESCRIPTION
## Summary

- Index username, display name, and real name in user cache
- `ResolveUser` accepts `@name` input, resolving from cache
- All user-accepting commands gain name resolution automatically
- Drops standalone `user lookup` command - unnecessary

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] Tests for: @name resolution, case-insensitive matching, not-found error

🤖 Generated with [Claude Code](https://claude.com/claude-code)