### PR TITLE
feat: output enrichment, cache management, version

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/tammersaleh/slack-cli/internal/output"
+)
+
+type CacheCmd struct {
+	Info  CacheInfoCmd  `cmd:"" help:"Show cache file info."`
+	Clear CacheClearCmd `cmd:"" help:"Delete all cache files."`
+}
+
+type CacheInfoCmd struct{}
+
+func (c *CacheInfoCmd) Run(cli *CLI) error {
+	p := cli.NewPrinter()
+	dir := cacheDir()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return p.PrintMeta(output.Meta{})
+		}
+		return &output.Error{Err: "cache_error", Detail: err.Error(), Code: output.ExitGeneral}
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		age := time.Since(info.ModTime())
+		if err := p.PrintItem(map[string]any{
+			"file":     entry.Name(),
+			"path":     filepath.Join(dir, entry.Name()),
+			"size":     info.Size(),
+			"modified": info.ModTime().UTC().Format(time.RFC3339),
+			"age":      age.Round(time.Second).String(),
+		}); err != nil {
+			return err
+		}
+	}
+
+	return p.PrintMeta(output.Meta{})
+}
+
+type CacheClearCmd struct{}
+
+func (c *CacheClearCmd) Run(cli *CLI) error {
+	p := cli.NewPrinter()
+	dir := cacheDir()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return p.PrintMeta(output.Meta{})
+		}
+		return &output.Error{Err: "cache_error", Detail: err.Error(), Code: output.ExitGeneral}
+	}
+
+	removed := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if err := os.Remove(path); err == nil {
+			removed++
+		}
+	}
+
+	if err := p.PrintItem(map[string]any{
+		"removed": removed,
+	}); err != nil {
+		return err
+	}
+	return p.PrintMeta(output.Meta{})
+}
+
+func cacheDir() string {
+	if dir, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(dir, "slack-cli", "cache")
+	}
+	return ""
+}

--- a/cmd/post_test.go
+++ b/cmd/post_test.go
@@ -154,7 +154,8 @@ func TestMessagePost_APIError(t *testing.T) {
 
 func TestMessagePost_Stdin(t *testing.T) {
 	var gotText string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		gotText = r.FormValue("text")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -162,7 +163,11 @@ func TestMessagePost_Stdin(t *testing.T) {
 			"channel": "C01ABC",
 			"ts":      "1709251200.000100",
 		})
-	}))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "members": []any{}})
+	})
+	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	t.Setenv("SLACK_TOKEN", "xoxb-test")
@@ -195,7 +200,8 @@ func TestMessagePost_Stdin(t *testing.T) {
 
 func TestMessagePost_StdinTrimsCarriageReturn(t *testing.T) {
 	var gotText string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		gotText = r.FormValue("text")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -203,7 +209,11 @@ func TestMessagePost_StdinTrimsCarriageReturn(t *testing.T) {
 			"channel": "C01ABC",
 			"ts":      "1709251200.000100",
 		})
-	}))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "members": []any{}})
+	})
+	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	t.Setenv("SLACK_TOKEN", "xoxb-test")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ type CLI struct {
 
 	Auth      AuthCmd      `cmd:"" help:"Manage authentication."`
 	Bookmark  BookmarkCmd  `cmd:"" help:"Channel bookmarks."`
+	Cache     CacheCmd     `cmd:"" help:"Cache management."`
 	Channel   ChannelCmd   `cmd:"" help:"Read channel information."`
 	Dnd       DndCmd       `cmd:"" help:"Do Not Disturb info."`
 	Emoji     EmojiCmd     `cmd:"" help:"Custom emoji."`
@@ -47,6 +48,7 @@ type CLI struct {
 	Thread    ThreadCmd    `cmd:"" help:"Read thread replies."`
 	User      UserCmd      `cmd:"" help:"Read user information."`
 	Usergroup UsergroupCmd `cmd:"" help:"User groups."`
+	Version       VersionCmd   `cmd:"" help:"Show version."`
 	WorkspaceInfo WorkspaceCmd `cmd:"" help:"Workspace info."`
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -26,6 +27,7 @@ type CLI struct {
 	// Set by NewClient from resolved credentials.
 	authMethod string
 	teamID     string
+	resolver   *resolve.Resolver
 
 	Auth      AuthCmd      `cmd:"" help:"Manage authentication."`
 	Bookmark  BookmarkCmd  `cmd:"" help:"Channel bookmarks."`
@@ -103,6 +105,11 @@ func (c *CLI) NewPrinter() *output.Printer {
 		Err:    errW,
 		Quiet:  c.Quiet,
 		Fields: c.ParsedFields(),
+		EnrichFunc: func(m map[string]any) {
+			if c.resolver != nil {
+				c.resolver.Enrich(context.Background(), m)
+			}
+		},
 	}
 }
 
@@ -158,10 +165,13 @@ func (c *CLI) ClassifyError(err error) *output.Error {
 }
 
 // NewResolver creates a channel/user name resolver from the API client.
+// The resolver is also stored on CLI for use by NewPrinter's enrichment.
 func (c *CLI) NewResolver(client *api.Client) *resolve.Resolver {
 	cacheDir := ""
 	if dir, err := os.UserConfigDir(); err == nil {
 		cacheDir = filepath.Join(dir, "slack-cli", "cache")
 	}
-	return resolve.NewResolver(client, c.teamID, cacheDir)
+	r := resolve.NewResolver(client, c.teamID, cacheDir)
+	c.resolver = r
+	return r
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -159,6 +159,10 @@ func TestSubcommands_Exist(t *testing.T) {
 		{"usergroup members", []string{"usergroup", "members", "S123"}},
 		{"emoji list", []string{"emoji", "list"}},
 		{"workspace info", []string{"workspace-info", "info"}},
+		{"cache info", []string{"cache", "info"}},
+		{"cache clear", []string{"cache", "clear"}},
+		{"version", []string{"version"}},
+		{"skill", []string{"skill"}},
 	}
 
 	for _, tt := range tests {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/tammersaleh/slack-cli/internal/output"
+)
+
+// Version is set at build time via -ldflags.
+var Version = "dev"
+
+type VersionCmd struct{}
+
+func (c *VersionCmd) Run(cli *CLI) error {
+	p := cli.NewPrinter()
+	if err := p.PrintItem(map[string]any{
+		"version": Version,
+	}); err != nil {
+		return err
+	}
+	return p.PrintMeta(output.Meta{})
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -50,10 +50,11 @@ type metaWrapper struct {
 
 // Printer writes JSONL output to stdout and errors to stderr.
 type Printer struct {
-	Out    io.Writer
-	Err    io.Writer
-	Quiet  bool
-	Fields []string // top-level field whitelist; empty means all fields
+	Out        io.Writer
+	Err        io.Writer
+	Quiet      bool
+	Fields     []string                // top-level field whitelist; empty means all fields
+	EnrichFunc func(m map[string]any)  // optional enrichment called on each item
 }
 
 // PrintItem writes a single data line as compact JSON with timestamp enrichment
@@ -77,6 +78,9 @@ func (p *Printer) PrintItem(v any) error {
 	}
 
 	enrichTimestamps(m)
+	if p.EnrichFunc != nil {
+		p.EnrichFunc(m)
+	}
 	m = filterFields(m, p.Fields)
 
 	out, err := json.Marshal(m)

--- a/internal/resolve/channel.go
+++ b/internal/resolve/channel.go
@@ -47,8 +47,7 @@ func (r *Resolver) ResolveChannel(ctx context.Context, input string) (string, er
 	if fc, err := r.loadFileCache(); err == nil && fc != nil {
 		if id, ok := fc.Channels[name]; ok {
 			r.mu.Lock()
-			r.channels = fc.Channels
-			r.channelsAt = time.Now()
+			r.setChannelMaps(fc.Channels)
 			r.mu.Unlock()
 			return id, nil
 		}
@@ -99,8 +98,7 @@ func (r *Resolver) resolveByPagination(ctx context.Context, name string) (string
 	}
 
 	// Update in-memory cache with whatever we fetched.
-	r.channels = channels
-	r.channelsAt = time.Now()
+	r.setChannelMaps(channels)
 
 	// Write file cache only on full pagination (found=="" means we exhausted all pages).
 	if found == "" {
@@ -109,6 +107,26 @@ func (r *Resolver) resolveByPagination(ctx context.Context, name string) (string
 	}
 
 	return found, nil
+}
+
+// setChannelMaps populates forward and reverse channel maps.
+// Must be called with r.mu held.
+func (r *Resolver) setChannelMaps(channels map[string]string) {
+	r.channels = channels
+	r.channelsAt = time.Now()
+	r.channelsByID = make(map[string]string, len(channels))
+	for name, id := range channels {
+		r.channelsByID[id] = name
+	}
+}
+
+// LookupChannelName returns the cached name for a channel ID.
+// Returns ("", false) if the channel is not in the cache.
+func (r *Resolver) LookupChannelName(id string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	name, ok := r.channelsByID[id]
+	return name, ok
 }
 
 // loadFileCache reads the channel file cache if it exists and is fresh.

--- a/internal/resolve/channel_test.go
+++ b/internal/resolve/channel_test.go
@@ -300,3 +300,40 @@ func TestResolveChannel_FileCacheWrittenAfterFullPagination(t *testing.T) {
 		t.Errorf("file cache missing random, got %v", cache.Channels)
 	}
 }
+
+func TestLookupChannelName(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"channels": []map[string]any{
+				{"id": "C111", "name": "general", "is_channel": true},
+				{"id": "C222", "name": "random", "is_channel": true},
+			},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		})
+	}))
+
+	r := NewResolver(client, "", "")
+
+	// Populate cache by resolving a channel.
+	_, err := r.ResolveChannel(context.Background(), "general")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reverse lookup should work.
+	name, ok := r.LookupChannelName("C111")
+	if !ok || name != "general" {
+		t.Errorf("expected general, got %q (ok=%v)", name, ok)
+	}
+	name, ok = r.LookupChannelName("C222")
+	if !ok || name != "random" {
+		t.Errorf("expected random, got %q (ok=%v)", name, ok)
+	}
+
+	// Unknown ID returns false.
+	_, ok = r.LookupChannelName("C999")
+	if ok {
+		t.Error("expected false for unknown channel")
+	}
+}

--- a/internal/resolve/enrich.go
+++ b/internal/resolve/enrich.go
@@ -1,0 +1,61 @@
+package resolve
+
+import (
+	"context"
+	"regexp"
+)
+
+var (
+	enrichUserPattern   = regexp.MustCompile(`^[UW][A-Z0-9]+$`)
+	enrichChannelPattern = regexp.MustCompile(`^C[A-Z0-9]+$`)
+)
+
+// enrichUserFields are top-level map keys that contain user IDs.
+var enrichUserFields = map[string]string{
+	"user":       "user_name",
+	"from_user":  "from_user_name",
+	"created_by": "created_by_name",
+}
+
+// enrichChannelFields are top-level map keys that contain channel IDs.
+var enrichChannelFields = map[string]string{
+	"channel":    "channel_name",
+	"channel_id": "channel_name",
+}
+
+// Enrich adds resolved names to a map for any recognized user/channel ID fields.
+// Enrichment is best-effort: missing cache entries are silently skipped.
+func (r *Resolver) Enrich(ctx context.Context, m map[string]any) {
+	// Warm caches if not already loaded. Errors are ignored -
+	// enrichment is best-effort.
+	_ = r.ensureUserCache(ctx)
+
+	for field, nameField := range enrichUserFields {
+		if _, already := m[nameField]; already {
+			continue
+		}
+		if id, ok := m[field].(string); ok && enrichUserPattern.MatchString(id) {
+			if user, found, _ := r.LookupUser(ctx, id); found {
+				name := user.Profile.DisplayName
+				if name == "" {
+					name = user.RealName
+				}
+				if name == "" {
+					name = user.Name
+				}
+				m[nameField] = name
+			}
+		}
+	}
+
+	for field, nameField := range enrichChannelFields {
+		if _, already := m[nameField]; already {
+			continue
+		}
+		if id, ok := m[field].(string); ok && enrichChannelPattern.MatchString(id) {
+			if name, found := r.LookupChannelName(id); found {
+				m[nameField] = name
+			}
+		}
+	}
+}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -31,9 +31,10 @@ type Resolver struct {
 	teamID   string
 	cacheDir string
 
-	mu         sync.RWMutex
-	channels   map[string]string // name -> ID
-	channelsAt time.Time
+	mu           sync.RWMutex
+	channels     map[string]string // name -> ID
+	channelsByID map[string]string // ID -> name
+	channelsAt   time.Time
 
 	users        map[string]slack.User // ID -> User
 	usersByEmail map[string]string     // email -> ID


### PR DESCRIPTION
## Summary

- **Output enrichment**: All output automatically includes `user_name` and `channel_name` alongside IDs, resolved from cache. Best-effort - missing entries silently skipped.
- **Reverse channel index**: `LookupChannelName(id)` for fast ID->name lookups from cache
- **`slack cache info`**: List cache files with size, age, path
- **`slack cache clear`**: Delete all cache files
- **`slack version`**: Print version (supports build-time ldflags)

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] LookupChannelName tested with forward+reverse lookup
- [x] All new subcommands in existence tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)