### PR TITLE
chore: improvement sweep - bugs, refactoring, enrichment gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,18 +122,36 @@ escalate when:
 
 ```
 cmd/
-  root.go        # CLI struct, global flags, NewPrinter/NewClient/NewResolver helpers
+  root.go        # CLI struct, global flags, NewPrinter/NewClient/NewResolver
   auth.go        # auth login/logout/status
+  bookmark.go    # bookmark list
+  cache.go       # cache info/clear
   channel.go     # channel list/info/members
+  dnd.go         # dnd info
+  emoji.go       # emoji list
+  file.go        # file list/info/download
   message.go     # message list (alias: read) / get
+  permalink.go   # message permalink
+  pin.go         # pin list
+  post.go        # message post
+  presence.go    # presence get
+  reaction.go    # reaction list
+  saved.go       # saved list/counts (internal API)
+  search.go      # search messages/files
+  section.go     # section list/channels/find/move/create (internal API)
+  skill.go       # generate Claude skill file
+  status.go      # status get
   thread.go      # thread list (alias: read)
   user.go        # user list/info
-  reaction.go    # reaction list
+  usergroup.go   # usergroup list/members
+  version.go     # version
+  workspace.go   # workspace info
 internal/
-  api/           # Slack API client wrapper (Client, Paginate[T], ClassifyError, WithCookie)
-  auth/          # credentials CRUD, OAuth flow, Desktop extraction, token resolution
-  output/        # Printer (JSONL), Meta, Error with exit codes
-  resolve/       # channel/user name-to-ID resolution with in-memory + file cache
+  api/           # Slack API client (Client, Paginate[T], ClassifyError,
+                 #   PostInternal, PostInternalForm, WithCookie)
+  auth/          # credentials CRUD, OAuth flow, Desktop extraction
+  output/        # Printer (JSONL + enrichment), Meta, Error with exit codes
+  resolve/       # channel/user resolution with 3-tier cache + enrichment
 ```
 
 ## Testing
@@ -152,12 +170,15 @@ JSONL to stdout. Every command emits one JSON object per line, ending with a `_m
 
 - No config file. All config via flags/env vars. Kong handles precedence.
 - Workspaces keyed by `TeamID` (stable) not `TeamName` (mutable) in credentials.json.
-- User resolution: ID + email only. Display name (`@name`) deferred to Phase 2 (expensive at scale). `users.lookupByEmail` fails with `xoxc-` tokens on Enterprise Grid (scope limitation).
+- User resolution: ID, email, or `@name` (display name / username / real name). Name lookups use the user cache index. `users.lookupByEmail` fails with `xoxc-` tokens on Enterprise Grid (scope limitation).
 - Channel resolution: first match wins on name collision. No ambiguity errors.
 - Channel list defaults to member-only. `--include-non-member` to expand.
 - Single-page pagination by default. `--cursor` to continue, `--all` to fetch everything.
 - `api.Paginate[T]` handles cursor-based pagination with rate-limit retry (5 attempts, respects Retry-After). `api.PaginateEach[T]` adds per-page callback with early exit. Both accept an endpoint name for diagnostics.
-- Channel resolver uses `PaginateEach` for early exit (stops paginating once target is found). File cache at `~/.config/slack-cli/cache/channels-{teamID}.json` (1h TTL) persists across invocations. In-memory cache (5min TTL) for session reuse.
+- Channel resolver uses `PaginateEach` for early exit (stops paginating once target is found). File cache at `~/.config/slack-cli/cache/channels-{teamID}.json` (24h TTL, configurable via `SLACK_CACHE_TTL`). In-memory cache (5min TTL) for session reuse. Reverse index (ID->name) for output enrichment.
+- User cache: file at `~/.config/slack-cli/cache/users-{teamID}.json` (24h TTL). Bulk-loads all users on first miss. Indexes by ID, email, and display name.
+- Output enrichment: all output automatically resolves user/channel IDs to names from cache. Best-effort, adds `user_name`/`channel_name` fields.
+- Internal APIs: `PostInternal` (JSON body) and `PostInternalForm` (form-encoded) for undocumented Slack endpoints (`saved.list`, `users.channelSections.*`).
 - `api.Client` wraps `slack-go/slack` with separate bot/user token clients. `WithCookie` injects `d` cookie + Chrome user-agent via custom `http.RoundTripper` for `xoxc-` tokens.
 - Desktop auth (`--desktop`) reads `xoxc-` tokens from Slack Desktop's LevelDB and decrypts the `d` cookie from its SQLite cookies DB using the Slack Safe Storage password (`SLACK_SAFE_STORAGE_PASSWORD` env var). Works with Enterprise Grid.
 - `auth_method` field in credentials.json tracks how each workspace was authenticated (`"oauth"` or `"desktop"`). Used for context-specific error hints.

--- a/cmd/bookmark.go
+++ b/cmd/bookmark.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/slack-go/slack"
 	"github.com/tammersaleh/slack-cli/internal/output"
@@ -45,9 +44,4 @@ func (c *BookmarkListCmd) Run(cli *CLI) error {
 	return p.PrintMeta(output.Meta{})
 }
 
-func bookmarkToMap(bm slack.Bookmark) map[string]any {
-	data, _ := json.Marshal(bm)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
+func bookmarkToMap(bm slack.Bookmark) map[string]any { return toMap(bm) }

--- a/cmd/channel.go
+++ b/cmd/channel.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/slack-go/slack"
@@ -217,10 +216,4 @@ func channelTypes(t string) []string {
 	}
 }
 
-func channelToMap(ch slack.Channel) map[string]any {
-	// Marshal via JSON to get a flat map with correct field names.
-	data, _ := json.Marshal(ch)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
+func channelToMap(ch slack.Channel) map[string]any { return toMap(ch) }

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -37,6 +37,7 @@ func (c *FileListCmd) Run(cli *CLI) error {
 		return err
 	}
 
+	r := cli.NewResolver(client) // also populates resolver for output enrichment
 	p := cli.NewPrinter()
 	ctx := context.Background()
 
@@ -47,7 +48,6 @@ func (c *FileListCmd) Run(cli *CLI) error {
 
 	channelID := c.Channel
 	if channelID != "" {
-		r := cli.NewResolver(client)
 		resolved, err := r.ResolveChannel(ctx, channelID)
 		if err == nil {
 			channelID = resolved
@@ -104,6 +104,7 @@ func (c *FileInfoCmd) Run(cli *CLI) error {
 		return err
 	}
 
+	cli.NewResolver(client) // populate resolver for output enrichment
 	p := cli.NewPrinter()
 	ctx := context.Background()
 	errorCount := 0

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -184,12 +183,7 @@ func (c *MessageGetCmd) Run(cli *CLI) error {
 	return nil
 }
 
-func messageToMap(msg slack.Message) map[string]any {
-	data, _ := json.Marshal(msg)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
+func messageToMap(msg slack.Message) map[string]any { return toMap(msg) }
 
 // parseTimestamp accepts a Unix timestamp string or ISO 8601 datetime.
 func parseTimestamp(s string) (string, error) {

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/slack-go/slack"
 	"github.com/tammersaleh/slack-cli/internal/output"
@@ -45,9 +44,4 @@ func (c *PinListCmd) Run(cli *CLI) error {
 	return p.PrintMeta(output.Meta{})
 }
 
-func pinItemToMap(item slack.Item) map[string]any {
-	data, _ := json.Marshal(item)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
+func pinItemToMap(item slack.Item) map[string]any { return toMap(item) }

--- a/cmd/reaction.go
+++ b/cmd/reaction.go
@@ -44,8 +44,8 @@ func (c *ReactionListCmd) Run(cli *CLI) error {
 				errorCount++
 				if err := p.PrintItem(map[string]any{
 					"input":  ts,
-					"error":  "message_not_found",
-					"detail": "No message at timestamp " + ts + " in " + c.Channel,
+					"error":  oErr.Err,
+					"detail": oErr.Detail,
 				}); err != nil {
 					return err
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -176,4 +177,25 @@ func (c *CLI) NewResolver(client *api.Client) *resolve.Resolver {
 	r := resolve.NewResolver(client, c.teamID, cacheDir)
 	c.resolver = r
 	return r
+}
+
+// toMap converts any struct to a map[string]any via JSON round-trip.
+func toMap(v any) map[string]any {
+	data, _ := json.Marshal(v)
+	var m map[string]any
+	_ = json.Unmarshal(data, &m)
+	return m
+}
+
+// requireSessionToken returns an error if the client's token is not an xoxc- session token.
+func requireSessionToken(client *api.Client) error {
+	if !strings.HasPrefix(client.Token(), "xoxc-") {
+		return &output.Error{
+			Err:    "session_token_required",
+			Detail: "This command requires a session token (xoxc-)",
+			Hint:   "Run 'slack auth login --desktop' to authenticate with a session token",
+			Code:   output.ExitAuth,
+		}
+	}
+	return nil
 }

--- a/cmd/saved.go
+++ b/cmd/saved.go
@@ -161,17 +161,6 @@ func (c *SavedCountsCmd) Run(cli *CLI) error {
 	return p.PrintMeta(output.Meta{})
 }
 
-func requireSessionToken(client *api.Client) error {
-	if !strings.HasPrefix(client.Token(), "xoxc-") {
-		return &output.Error{
-			Err:    "session_token_required",
-			Detail: "saved commands require a session token (xoxc-)",
-			Hint:   "Run 'slack auth login --desktop' to authenticate with a session token",
-			Code:   output.ExitAuth,
-		}
-	}
-	return nil
-}
 
 func formatSavedItem(item savedItem) map[string]any {
 	tsNoDot := strings.ReplaceAll(item.TS, ".", "")

--- a/cmd/saved.go
+++ b/cmd/saved.go
@@ -61,6 +61,7 @@ func (c *SavedListCmd) Run(cli *CLI) error {
 		return err
 	}
 
+	cli.NewResolver(client) // populate resolver for output enrichment
 	p := cli.NewPrinter()
 	ctx := context.Background()
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -203,16 +202,5 @@ func (c *SearchFilesCmd) Run(cli *CLI) error {
 	}
 }
 
-func fileToMap(f slack.File) map[string]any {
-	data, _ := json.Marshal(f)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
-
-func searchMessageToMap(msg slack.SearchMessage) map[string]any {
-	data, _ := json.Marshal(msg)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
+func fileToMap(f slack.File) map[string]any          { return toMap(f) }
+func searchMessageToMap(msg slack.SearchMessage) map[string]any { return toMap(msg) }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -45,6 +45,7 @@ func (c *SearchMessagesCmd) Run(cli *CLI) error {
 		}
 	}
 
+	cli.NewResolver(client) // populate resolver for output enrichment
 	p := cli.NewPrinter()
 	ctx := context.Background()
 
@@ -137,6 +138,7 @@ func (c *SearchFilesCmd) Run(cli *CLI) error {
 		}
 	}
 
+	cli.NewResolver(client) // populate resolver for output enrichment
 	p := cli.NewPrinter()
 	ctx := context.Background()
 

--- a/cmd/thread.go
+++ b/cmd/thread.go
@@ -52,11 +52,7 @@ func (c *ThreadListCmd) Run(cli *CLI) error {
 			Cursor:    cursor,
 		})
 		if err != nil {
-			oErr := cli.ClassifyError(err)
-			if oErr.Err == "thread_not_found" || oErr.Err == "channel_not_found" {
-				return oErr
-			}
-			return oErr
+			return cli.ClassifyError(err)
 		}
 
 		if len(msgs) == 0 {

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/slack-go/slack"
@@ -144,12 +143,7 @@ func (c *UserInfoCmd) Run(cli *CLI) error {
 	return nil
 }
 
-func userToMap(u slack.User) map[string]any {
-	data, _ := json.Marshal(u)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
+func userToMap(u slack.User) map[string]any { return toMap(u) }
 
 func matchesUserQuery(u slack.User, query string) bool {
 	q := strings.ToLower(query)

--- a/cmd/usergroup.go
+++ b/cmd/usergroup.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/slack-go/slack"
@@ -77,9 +76,4 @@ func (c *UsergroupMembersCmd) Run(cli *CLI) error {
 	return p.PrintMeta(output.Meta{})
 }
 
-func usergroupToMap(g slack.UserGroup) map[string]any {
-	data, _ := json.Marshal(g)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
+func usergroupToMap(g slack.UserGroup) map[string]any { return toMap(g) }

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/slack-go/slack"
 	"github.com/tammersaleh/slack-cli/internal/output"
@@ -34,9 +33,4 @@ func (c *WorkspaceInfoCmd) Run(cli *CLI) error {
 	return p.PrintMeta(output.Meta{})
 }
 
-func teamToMap(t slack.TeamInfo) map[string]any {
-	data, _ := json.Marshal(t)
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	return m
-}
+func teamToMap(t slack.TeamInfo) map[string]any { return toMap(t) }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	var cli cmd.CLI
 	ctx := kong.Parse(&cli,
 		kong.Name("slack"),
-		kong.Description("Read-only CLI for Slack."),
+		kong.Description("CLI for Slack."),
 		kong.UsageOnError(),
 	)
 


### PR DESCRIPTION
## Summary

Five-pass improvement sweep across the entire codebase.

### Bugs fixed

- `main.go` said "Read-only CLI" but `message post` exists
- `thread.go` dead code: both branches of error conditional returned same thing
- `reaction.go` hardcoded `message_not_found` instead of using classified error

### Code quality

- Extract generic `toMap()` replacing 9 identical marshal/unmarshal functions
- Move `requireSessionToken` from `saved.go` to `root.go` (used by both saved and section)
- Remove 7 unused `encoding/json` imports

### Enrichment gaps

- Add resolver to search messages/files, saved list, file list/info for output enrichment

### Documentation

- Update CLAUDE.md project structure (was missing 17 new files)
- Fix stale architecture decisions (user resolution, TTL, etc.)

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)