### PR TITLE
chore: remaining fixes from improvement sweep

### DIFF
--- a/cmd/cache_test.go
+++ b/cmd/cache_test.go
@@ -1,0 +1,49 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCacheInfo_Empty(t *testing.T) {
+	// With no cache files, should emit just _meta.
+	t.Setenv("HOME", t.TempDir())
+
+	mux := emptyMux()
+	out, err := runWithMock(t, mux, "cache", "info")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line (meta only), got %d:\n%s", len(lines), out)
+	}
+}
+
+func TestCacheClear(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create a fake cache file.
+	cacheDir := filepath.Join(home, "Library", "Application Support", "slack-cli", "cache")
+	_ = os.MkdirAll(cacheDir, 0700)
+	_ = os.WriteFile(filepath.Join(cacheDir, "channels-T123.json"), []byte(`{}`), 0600)
+
+	mux := emptyMux()
+	out, err := runWithMock(t, mux, "cache", "clear")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["removed"] != float64(1) {
+		t.Errorf("expected removed=1, got %v", item["removed"])
+	}
+}

--- a/cmd/channel.go
+++ b/cmd/channel.go
@@ -186,7 +186,7 @@ func (c *ChannelMembersCmd) Run(cli *CLI) error {
 		}
 
 		for _, uid := range members {
-			if err := p.PrintItem(map[string]string{"id": uid}); err != nil {
+			if err := p.PrintItem(map[string]any{"user_id": uid}); err != nil {
 				return err
 			}
 		}

--- a/cmd/channel_test.go
+++ b/cmd/channel_test.go
@@ -395,8 +395,8 @@ func TestChannelMembers_MockAPI(t *testing.T) {
 	}
 
 	member := parseJSON(t, lines[0])
-	if member["id"] != "U01" {
-		t.Errorf("expected first member 'U01', got %q", member["id"])
+	if member["user_id"] != "U01" {
+		t.Errorf("expected first member 'U01', got %q", member["user_id"])
 	}
 }
 

--- a/cmd/channel_test.go
+++ b/cmd/channel_test.go
@@ -62,6 +62,11 @@ func runWithMock(t *testing.T, handler http.Handler, args ...string) (string, er
 	return r.stdout, r.err
 }
 
+// emptyMux returns a ServeMux with no handlers for commands that don't call APIs.
+func emptyMux() *http.ServeMux {
+	return http.NewServeMux()
+}
+
 func nonEmptyLines(s string) []string {
 	var result []string
 	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {

--- a/cmd/dnd_test.go
+++ b/cmd/dnd_test.go
@@ -1,0 +1,42 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestDndInfo(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dnd.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if u := r.FormValue("user"); u != "U01ABC" {
+			t.Errorf("expected user='U01ABC', got %q", u)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":                 true,
+			"dnd_enabled":        true,
+			"next_dnd_start_ts":  1709272800,
+			"next_dnd_end_ts":    1709308800,
+			"snooze_enabled":     false,
+		})
+	})
+
+	out, err := runWithMock(t, mux, "dnd", "info", "U01ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["dnd_enabled"] != true {
+		t.Errorf("expected dnd_enabled=true, got %v", item["dnd_enabled"])
+	}
+	if item["user_id"] != "U01ABC" {
+		t.Errorf("expected user_id='U01ABC', got %q", item["user_id"])
+	}
+}

--- a/cmd/emoji_test.go
+++ b/cmd/emoji_test.go
@@ -1,0 +1,60 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestEmojiList(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/emoji.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"emoji": map[string]string{
+				"partyparrot": "https://emoji.slack-edge.com/partyparrot.gif",
+				"thumbsup":    "alias:+1",
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "emoji", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (2 emoji + meta), got %d:\n%s", len(lines), out)
+	}
+}
+
+func TestEmojiList_Query(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/emoji.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"emoji": map[string]string{
+				"partyparrot": "https://emoji.slack-edge.com/partyparrot.gif",
+				"party_blob":  "https://emoji.slack-edge.com/party_blob.png",
+				"thumbsup":    "alias:+1",
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "emoji", "list", "--query", "party")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	// 2 matches (partyparrot, party_blob) + meta
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (2 matches + meta), got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["name"] == "thumbsup" {
+		t.Error("thumbsup should be filtered out by --query party")
+	}
+}

--- a/cmd/presence_test.go
+++ b/cmd/presence_test.go
@@ -1,0 +1,38 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestPresenceGet(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/users.getPresence", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":          true,
+			"presence":    "active",
+			"online":      true,
+			"auto_away":   false,
+			"manual_away": false,
+		})
+	})
+
+	out, err := runWithMock(t, mux, "presence", "get", "U01ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["presence"] != "active" {
+		t.Errorf("expected presence='active', got %q", item["presence"])
+	}
+	if item["user_id"] != "U01ABC" {
+		t.Errorf("expected user_id='U01ABC', got %q", item["user_id"])
+	}
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,119 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestStatusGet_WithUser(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/users.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"members": []map[string]any{
+				{
+					"id":        "U01ABC",
+					"name":      "tammer",
+					"real_name": "Tammer Saleh",
+					"profile": map[string]any{
+						"email":             "tammer@example.com",
+						"status_text":       "In a meeting",
+						"status_emoji":      ":calendar:",
+						"status_expiration": 1709254800,
+					},
+				},
+			},
+		})
+	})
+	mux.HandleFunc("/api/users.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"user": map[string]any{
+				"id":        "U01ABC",
+				"name":      "tammer",
+				"real_name": "Tammer Saleh",
+				"profile": map[string]any{
+					"status_text":       "In a meeting",
+					"status_emoji":      ":calendar:",
+					"status_expiration": 1709254800,
+				},
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "status", "get", "U01ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["status_text"] != "In a meeting" {
+		t.Errorf("expected status_text='In a meeting', got %q", item["status_text"])
+	}
+	if item["user_id"] != "U01ABC" {
+		t.Errorf("expected user_id='U01ABC', got %q", item["user_id"])
+	}
+}
+
+func TestStatusGet_DefaultUser(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/auth.test", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"url":     "https://acme.slack.com/",
+			"team":    "Acme",
+			"team_id": "T01",
+			"user":    "tammer",
+			"user_id": "U01ABC",
+		})
+	})
+	mux.HandleFunc("/api/users.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"members": []map[string]any{
+				{
+					"id":   "U01ABC",
+					"name": "tammer",
+					"profile": map[string]any{
+						"status_text":  "Working",
+						"status_emoji": ":computer:",
+					},
+				},
+			},
+		})
+	})
+	mux.HandleFunc("/api/users.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"user": map[string]any{
+				"id":   "U01ABC",
+				"name": "tammer",
+				"profile": map[string]any{
+					"status_text":  "Working",
+					"status_emoji": ":computer:",
+				},
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "status", "get")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["status_text"] != "Working" {
+		t.Errorf("expected status_text='Working', got %q", item["status_text"])
+	}
+}

--- a/cmd/usergroup_test.go
+++ b/cmd/usergroup_test.go
@@ -1,0 +1,86 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestUsergroupList(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/usergroups.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"usergroups": []map[string]any{
+				{"id": "S01ABC", "name": "Engineering", "handle": "engineering", "user_count": 34},
+				{"id": "S02DEF", "name": "Design", "handle": "design", "user_count": 12},
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "usergroup", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (2 groups + meta), got %d:\n%s", len(lines), out)
+	}
+
+	g := parseJSON(t, lines[0])
+	if g["id"] != "S01ABC" {
+		t.Errorf("expected id='S01ABC', got %q", g["id"])
+	}
+	if g["name"] != "Engineering" {
+		t.Errorf("expected name='Engineering', got %q", g["name"])
+	}
+}
+
+func TestUsergroupList_Query(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/usergroups.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"usergroups": []map[string]any{
+				{"id": "S01ABC", "name": "Engineering"},
+				{"id": "S02DEF", "name": "Design"},
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "usergroup", "list", "--query", "eng")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (1 match + meta), got %d:\n%s", len(lines), out)
+	}
+}
+
+func TestUsergroupMembers(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/usergroups.users.list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    true,
+			"users": []string{"U01", "U02", "U03"},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "usergroup", "members", "S01ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines (3 members + meta), got %d:\n%s", len(lines), out)
+	}
+
+	m := parseJSON(t, lines[0])
+	if m["user_id"] != "U01" {
+		t.Errorf("expected user_id='U01', got %q", m["user_id"])
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,27 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	mux := emptyMux()
+	out, err := runWithMock(t, mux, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (version + meta), got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["version"] == nil || item["version"] == "" {
+		t.Error("expected non-empty version")
+	}
+	if !strings.Contains(lines[1], "_meta") {
+		t.Error("expected _meta trailer")
+	}
+}

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -1,0 +1,39 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestWorkspaceInfo(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/team.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"team": map[string]any{
+				"id":     "T01ABC",
+				"name":   "Acme Corp",
+				"domain": "acme",
+			},
+		})
+	})
+
+	out, err := runWithMock(t, mux, "workspace-info", "info")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), out)
+	}
+
+	item := parseJSON(t, lines[0])
+	if item["id"] != "T01ABC" {
+		t.Errorf("expected id='T01ABC', got %q", item["id"])
+	}
+	if item["name"] != "Acme Corp" {
+		t.Errorf("expected name='Acme Corp', got %q", item["name"])
+	}
+}

--- a/internal/resolve/enrich.go
+++ b/internal/resolve/enrich.go
@@ -13,6 +13,7 @@ var (
 // enrichUserFields are top-level map keys that contain user IDs.
 var enrichUserFields = map[string]string{
 	"user":       "user_name",
+	"user_id":    "user_name",
 	"from_user":  "from_user_name",
 	"created_by": "created_by_name",
 }


### PR DESCRIPTION
## Summary

Remaining fixes from the five-pass improvement sweep.

### Member enrichment

- `channel members` now outputs `user_id` instead of bare `id`
- Add `user_id` to enrichment field map so members get automatic name resolution

### Missing tests (8 new test files)

- `version_test.go` - version output
- `workspace_test.go` - team.info
- `emoji_test.go` - list + --query filter
- `usergroup_test.go` - list + --query, members
- `dnd_test.go` - dnd.info
- `presence_test.go` - users.getPresence
- `status_test.go` - with user + default user (auth.test path)
- `cache_test.go` - info (empty) + clear

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] Every cmd/*.go now has a corresponding test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)