### PR TITLE
fix: second improvement sweep

### DIFF
--- a/cmd/channel.go
+++ b/cmd/channel.go
@@ -115,11 +115,15 @@ func (c *ChannelInfoCmd) Run(cli *CLI) error {
 			IncludeNumMembers: true,
 		})
 		if err != nil {
+			oErr := cli.ClassifyError(err)
+			if oErr.Code != output.ExitGeneral {
+				return oErr
+			}
 			errorCount++
 			if err := p.PrintItem(map[string]any{
 				"input":  input,
-				"error":  "channel_not_found",
-				"detail": "No channel matching '" + input + "'",
+				"error":  oErr.Err,
+				"detail": oErr.Detail,
 			}); err != nil {
 				return err
 			}

--- a/cmd/dnd.go
+++ b/cmd/dnd.go
@@ -41,7 +41,19 @@ func (c *DndInfoCmd) Run(cli *CLI) error {
 
 		dnd, err := client.Bot().GetDNDInfoContext(ctx, &userID)
 		if err != nil {
-			return cli.ClassifyError(err)
+			oErr := cli.ClassifyError(err)
+			if oErr.Code != output.ExitGeneral {
+				return oErr
+			}
+			errorCount++
+			if err := p.PrintItem(map[string]any{
+				"input":  input,
+				"error":  oErr.Err,
+				"detail": oErr.Detail,
+			}); err != nil {
+				return err
+			}
+			continue
 		}
 
 		if err := p.PrintItem(map[string]any{

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -151,7 +151,19 @@ func (c *MessageGetCmd) Run(cli *CLI) error {
 			Limit:     1,
 		})
 		if err != nil {
-			return cli.ClassifyError(err)
+			oErr := cli.ClassifyError(err)
+			if oErr.Code != output.ExitGeneral {
+				return oErr
+			}
+			errorCount++
+			if err := p.PrintItem(map[string]any{
+				"input":  ts,
+				"error":  oErr.Err,
+				"detail": oErr.Detail,
+			}); err != nil {
+				return err
+			}
+			continue
 		}
 
 		if len(resp.Messages) == 0 {

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -184,3 +184,43 @@ func TestMessageList_Pagination(t *testing.T) {
 		t.Errorf("expected next_cursor='nextpage', got %q", m["next_cursor"])
 	}
 }
+
+func TestMessageList_EnrichesUserName(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations.history", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":       true,
+			"has_more": false,
+			"messages": []map[string]any{
+				{"type": "message", "user": "U01", "text": "hello", "ts": "1709251200.000100"},
+			},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		})
+	})
+	mux.HandleFunc("/api/users.list", func(w http.ResponseWriter, r *http.Request) {
+		resp := struct {
+			OK      bool              `json:"ok"`
+			Members []map[string]any  `json:"members"`
+		}{
+			OK: true,
+			Members: []map[string]any{
+				{"id": "U01", "name": "tammer", "real_name": "Tammer Saleh", "profile": map[string]any{"email": "t@example.com"}},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	out, err := runWithMock(t, mux, "message", "list", "C01ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := nonEmptyLines(out)
+	msg := parseJSON(t, lines[0])
+	if msg["user"] != "U01" {
+		t.Errorf("expected user='U01', got %q", msg["user"])
+	}
+	if msg["user_name"] == nil || msg["user_name"] == "" {
+		t.Error("expected user_name to be enriched from cache")
+	}
+}

--- a/cmd/post_test.go
+++ b/cmd/post_test.go
@@ -164,9 +164,6 @@ func TestMessagePost_Stdin(t *testing.T) {
 			"ts":      "1709251200.000100",
 		})
 	})
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "members": []any{}})
-	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
@@ -209,9 +206,6 @@ func TestMessagePost_StdinTrimsCarriageReturn(t *testing.T) {
 			"channel": "C01ABC",
 			"ts":      "1709251200.000100",
 		})
-	})
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "members": []any{}})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/cmd/presence.go
+++ b/cmd/presence.go
@@ -41,7 +41,19 @@ func (c *PresenceGetCmd) Run(cli *CLI) error {
 
 		presence, err := client.Bot().GetUserPresenceContext(ctx, userID)
 		if err != nil {
-			return cli.ClassifyError(err)
+			oErr := cli.ClassifyError(err)
+			if oErr.Code != output.ExitGeneral {
+				return oErr
+			}
+			errorCount++
+			if err := p.PrintItem(map[string]any{
+				"input":  input,
+				"error":  oErr.Err,
+				"detail": oErr.Detail,
+			}); err != nil {
+				return err
+			}
+			continue
 		}
 
 		if err := p.PrintItem(map[string]any{

--- a/cmd/presence_test.go
+++ b/cmd/presence_test.go
@@ -9,6 +9,10 @@ import (
 func TestPresenceGet(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/users.getPresence", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if u := r.FormValue("user"); u != "U01ABC" {
+			t.Errorf("expected user='U01ABC', got %q", u)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":          true,
 			"presence":    "active",

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -158,6 +158,6 @@ everything, or use the ` + "`next_cursor`" + ` from ` + "`_meta`" + ` with ` + "
 
 ## Channel and User Resolution
 
-Channels accept IDs (C...) or #names. Users accept IDs (U...), emails,
+Channels accept IDs (C.../G.../D...) or #names. Users accept IDs (U...), emails,
 or @display-names.
 `

--- a/internal/resolve/channel.go
+++ b/internal/resolve/channel.go
@@ -143,6 +143,7 @@ func (r *Resolver) loadFileCache() (*channelFileCache, error) {
 
 	var fc channelFileCache
 	if err := json.Unmarshal(data, &fc); err != nil {
+		_ = os.Remove(path) // clean up corrupted cache
 		return nil, err
 	}
 

--- a/internal/resolve/channel.go
+++ b/internal/resolve/channel.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tammersaleh/slack-cli/internal/api"
 )
 
-var channelIDPattern = regexp.MustCompile(`^[C][A-Z0-9]+$`)
+var channelIDPattern = regexp.MustCompile(`^[CDG][A-Z0-9]+$`)
 
 // channelFileCache is the on-disk format for the channel name cache.
 type channelFileCache struct {

--- a/internal/resolve/channel_test.go
+++ b/internal/resolve/channel_test.go
@@ -23,12 +23,25 @@ func newTestClient(t *testing.T, handler http.Handler) *api.Client {
 func TestResolveChannel_IDPassthrough(t *testing.T) {
 	// No API calls needed for IDs.
 	r := NewResolver(api.NewWithAPIURL("xoxb-unused", "http://unused/api/"), "", "")
-	id, err := r.ResolveChannel(context.Background(), "C01ABC123")
-	if err != nil {
-		t.Fatal(err)
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"C prefix (channel)", "C01ABC123"},
+		{"G prefix (group DM)", "G01ABC123"},
+		{"D prefix (DM)", "D01ABC123"},
 	}
-	if id != "C01ABC123" {
-		t.Errorf("got %q, want %q", id, "C01ABC123")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := r.ResolveChannel(context.Background(), tt.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if id != tt.input {
+				t.Errorf("got %q, want %q", id, tt.input)
+			}
+		})
 	}
 }
 

--- a/internal/resolve/enrich.go
+++ b/internal/resolve/enrich.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	enrichUserPattern   = regexp.MustCompile(`^[UW][A-Z0-9]+$`)
-	enrichChannelPattern = regexp.MustCompile(`^C[A-Z0-9]+$`)
+	enrichChannelPattern = regexp.MustCompile(`^[CDG][A-Z0-9]+$`)
 )
 
 // enrichUserFields are top-level map keys that contain user IDs.

--- a/internal/resolve/user.go
+++ b/internal/resolve/user.go
@@ -176,6 +176,7 @@ func (r *Resolver) loadUserFileCache() (*userFileCache, error) {
 
 	var fc userFileCache
 	if err := json.Unmarshal(data, &fc); err != nil {
+		_ = os.Remove(path) // clean up corrupted cache
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Second round of codebase-wide improvement sweep.

### Bugs fixed

- **Channel ID pattern** accepted only `C` prefix. Now accepts `G` (group DM) and `D` (DM) too.
- **dnd info / presence get** fatal error in multi-user loop instead of per-item inline. Auth errors killed the entire command mid-loop with no _meta trailer.
- **channel info** hardcoded `channel_not_found` for all API errors - auth and rate limit errors were silently swallowed as "not found".
- **message get** API errors in the timestamp loop were fatal instead of per-item, producing no _meta trailer on partial failure.
- **Corrupted cache files** retried forever. Now deleted on parse failure.

### Test improvements

- End-to-end enrichment test verifying `user_name` appears in message output
- Removed catch-all `/` handlers from stdin tests (were hiding endpoint routing bugs)
- Added user ID verification to presence test handler
- Channel ID passthrough tests for G/D prefixes

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)