### PR TITLE
fix: third improvement sweep

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -14,6 +14,27 @@
 - `user list --query @tammer` searches for the literal string `@tammer`
   instead of stripping the `@` prefix first.
 
+- `--fields` strips enrichment-added fields (`user_name`, `channel_name`,
+  `ts_iso`) because filtering runs after enrichment. Use
+  `--fields user,user_name` to get both. Documented in skill file.
+
+- `channel members` output uses `user_id` as the field name, but
+  SPEC.md shows `id`. The enrichment system relies on `user_id`.
+
+- `message list` and `thread list` don't include `channel_id` in each
+  item's output. Agents can't construct follow-up commands (`message
+  permalink`, `reaction list`) from piped output alone without knowing
+  the channel from the original command.
+
+## Performance
+
+- HTTP/2 connections are not multiplexed. The Chrome TLS transport
+  creates a new H2 connection per API request rather than reusing one.
+  Correct but wasteful.
+
+- The `go 1.25.0` requirement in go.mod is higher than necessary.
+  The codebase only uses Go 1.22 features (range-over-integer).
+
 ## Test quality
 
 - Resolver channel tests (`internal/resolve/channel_test.go`) use

--- a/cmd/saved.go
+++ b/cmd/saved.go
@@ -215,6 +215,7 @@ func enrichItems(ctx context.Context, client *api.Client, items []savedItem) map
 			// Fetch message text.
 			resp, err := client.Bot().GetConversationHistoryContext(ctx, &slack.GetConversationHistoryParameters{
 				ChannelID: item.ItemID,
+				Oldest:    item.TS,
 				Latest:    item.TS,
 				Inclusive: true,
 				Limit:     1,

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -151,6 +151,17 @@ slack usergroup members <group-id>
 slack workspace-info info
 ` + "```" + `
 
+## Enrichment
+
+Output automatically includes resolved names alongside IDs:
+
+- ` + "`user`" + ` fields gain a ` + "`user_name`" + ` sibling
+- ` + "`channel`" + ` / ` + "`channel_id`" + ` fields gain a ` + "`channel_name`" + ` sibling
+- ` + "`ts`" + ` and ` + "`*_ts`" + ` fields gain a ` + "`*_iso`" + ` sibling (RFC3339)
+
+When using ` + "`--fields`" + `, include enriched field names explicitly
+(e.g. ` + "`--fields user,user_name`" + `).
+
 ## Pagination
 
 Most list commands return one page by default. Use ` + "`--all`" + ` to fetch

--- a/internal/api/transport.go
+++ b/internal/api/transport.go
@@ -149,6 +149,7 @@ func (t *chromeTLSTransport) RoundTrip(req *http.Request) (*http.Response, error
 // singleConnRoundTrip performs an HTTP/1.1 request over an existing TLS connection.
 func singleConnRoundTrip(conn net.Conn, req *http.Request) (*http.Response, error) {
 	t := &http.Transport{
+		DisableKeepAlives: true,
 		DialTLSContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 			return conn, nil
 		},

--- a/internal/auth/desktop.go
+++ b/internal/auth/desktop.go
@@ -221,6 +221,9 @@ func extractCookie(cookiesPath, password string) (string, error) {
 			}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("reading cookies: %w", err)
+	}
 
 	return "", fmt.Errorf("d cookie not found in Slack cookies database")
 }

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -59,7 +60,7 @@ func login(ctx context.Context, baseURL, clientID, clientSecret string) (*Worksp
 
 	authURL := buildAuthorizeURL(baseURL, clientID, redirectURI, state)
 	openBrowser(authURL)
-	fmt.Printf("Opening browser for authentication...\nIf it doesn't open, visit:\n%s\n", authURL)
+	fmt.Fprintf(os.Stderr, "Opening browser for authentication...\nIf it doesn't open, visit:\n%s\n", authURL)
 
 	// Wait for the callback or timeout.
 	var code string

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/alecthomas/kong"
@@ -40,6 +39,5 @@ func main() {
 		"error":  "general_error",
 		"detail": err.Error(),
 	})
-	fmt.Fprintln(os.Stderr)
 	os.Exit(output.ExitGeneral)
 }


### PR DESCRIPTION
## Summary

Third round of full codebase audit, focused on architecture, transport, auth, and agent UX.

### Fixes

- **Transport goroutine leak**: `singleConnRoundTrip` missing `DisableKeepAlives`, could leak goroutines on HTTP/1.1 connections
- **OAuth stdout pollution**: `fmt.Printf` during browser auth wrote to stdout, corrupting JSONL output. Moved to stderr.
- **main.go spurious newline**: Extra `fmt.Fprintln` after unstructured error JSON removed
- **Desktop auth diagnostic gap**: `rows.Err()` unchecked after cookie DB query loop
- **Saved list enrichment**: Used `Latest` only instead of `Oldest=Latest` pattern for message fetch. Could return wrong message if target was deleted.
- **Skill file**: Added enrichment documentation (user_name, channel_name, ts_iso fields and --fields interaction)
- **KNOWN_ISSUES.md**: Updated with new findings

## Test plan

- [x] All tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)